### PR TITLE
chore: sync package-lock.json to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-glossary",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-glossary",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "firebase": "^12.12.0",
         "lucide-react": "^0.446.0",


### PR DESCRIPTION
## Summary
- `package-lock.json` was still pinned to `0.7.0` while `package.json` is `0.8.0`. Running `npm install` during a bug scan synced the lockfile; committing that one-line fix to keep the tree clean.

## Test plan
- [ ] `npm install` produces no further lockfile drift
- [ ] `npm run build` still succeeds

https://claude.ai/code/session_01BN7cP564xSsfEUU2TMBJae