### PR TITLE
fix(test): stub Firebase SDK so App and ExploreBar suites run

### DIFF
--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,19 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Stub the Firebase SDK so importing src/firebase.js doesn't blow up in tests
+// when VITE_FIREBASE_* env vars aren't set. Hooks using these mocks see an
+// empty snapshot, so they keep the local glossary/categories data.
+vi.mock('firebase/app', () => ({
+  initializeApp: vi.fn(() => ({})),
+}));
+
+vi.mock('firebase/analytics', () => ({
+  getAnalytics: vi.fn(() => ({})),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  collection: vi.fn(() => ({})),
+  getDocs: vi.fn(() => Promise.resolve({ empty: true, forEach: () => {} })),
+}));


### PR DESCRIPTION
## Summary

Bug check found two failing test suites: `src/test/App.test.jsx` and `src/test/ExploreBar.test.jsx` both threw `FirebaseError: Missing App configuration value: "projectId"` at module load, so 0 tests in those files ran (27 tests skipped).

**Root cause:** Both files transitively import `src/firebase.js`, which calls `initializeApp(firebaseConfig)` and `getAnalytics(app)` with empty config because `VITE_FIREBASE_*` env vars are never set in the test environment.

**Fix:** Stub `firebase/app`, `firebase/analytics`, and `firebase/firestore` in `src/test/setup.js`. The `getDocs` stub returns an empty snapshot, so `useGlossary` and `useCategories` cleanly fall back to the local data they already use as initial state.

Test results: **10/10 files pass, 952/952 tests pass** (was 8/10 files, 925 tests).

Production code is unchanged — env vars still drive real Firebase init in `npm run dev`/`build`.

## Test plan

- [x] `npm run test` — all 952 tests pass
- [x] `npm run build` — succeeds
- [ ] `npm run dev` in a real session to confirm Firebase still initializes from env vars (out of scope for this sandbox)

https://claude.ai/code/session_011TD2Rzym4C8crc4ujHGUB8

---
_Generated by [Claude Code](https://claude.ai/code/session_011TD2Rzym4C8crc4ujHGUB8)_