### PR TITLE
fix(firebase): guard analytics init so tests stop crashing on import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-glossary",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-glossary",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "firebase": "^12.12.0",
         "lucide-react": "^0.446.0",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,5 +13,10 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
-export const analytics = getAnalytics(app);
+// Analytics requires projectId + a browser environment. Skip it in tests or
+// when env vars are absent so importing this module never throws.
+export const analytics =
+  firebaseConfig.projectId && typeof window !== 'undefined'
+    ? getAnalytics(app)
+    : null;
 export const db = getFirestore(app);


### PR DESCRIPTION
## Bug

`src/firebase.js` called `getAnalytics(app)` at module-load time. When `VITE_FIREBASE_PROJECT_ID` isn't set (the test environment, or any local checkout without `.env`), Firebase throws:

```
FirebaseError: Installations: Missing App configuration value: "projectId"
```

Because `ExploreBar.jsx` transitively imports `firebase.js` via `useCategories` / `useGlossary`, two test files crashed at import time and never ran any of their cases:

- `src/test/App.test.jsx`
- `src/test/ExploreBar.test.jsx`

`vitest` reported them as "0 test" failed suites.

## Fix

Initialize `analytics` only when both `projectId` and a browser `window` are available; export `null` otherwise. The exported `analytics` constant is not referenced anywhere else in the codebase, so making it nullable is safe.

## Result

- Before: `Test Files  2 failed | 8 passed (10) / Tests 925 passed`
- After: `Test Files  10 passed (10) / Tests 952 passed` (+27 tests now actually run)
- `npm run build` still succeeds.

## Test plan

- [x] `npm test` — 10/10 suites pass, 952/952 tests pass
- [x] `npm run build` — succeeds
- [ ] Production deploy still wires up analytics when env vars are present (verify in browser console after `/deploy`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKDbMEkczTh77d21WhgWYF)_