### PR TITLE
fix(tests): mock Firebase in setup so App + ExploreBar suites load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-glossary",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-glossary",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "firebase": "^12.12.0",
         "lucide-react": "^0.446.0",

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Stub Firebase so test suites that pull in `src/firebase.js` (via App, ExploreBar,
+// or the data hooks) don't try to initialize analytics with empty env vars.
+vi.mock('firebase/app', () => ({
+  initializeApp: vi.fn(() => ({})),
+}));
+
+vi.mock('firebase/analytics', () => ({
+  getAnalytics: vi.fn(() => ({})),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  collection: vi.fn(() => ({})),
+  getDocs: vi.fn(() => Promise.resolve({ empty: true, forEach: () => {} })),
+}));


### PR DESCRIPTION
## Summary

- Two test suites (`App.test.jsx`, `ExploreBar.test.jsx`) were registering **0 tests** and failing to load. Cause: `src/firebase.js` calls `getAnalytics(app)` at module load, which throws `Installations: Missing App configuration value: "projectId"` when `VITE_FIREBASE_*` env vars are unset — exactly the test environment.
- Fix mocks `firebase/app`, `firebase/analytics`, and `firebase/firestore` globally in `src/test/setup.js` so any suite that transitively imports `src/firebase.js` (via `App`, `ExploreBar`, or the data hooks) can load cleanly. `analytics` is unused outside `firebase.js` itself; the data hooks (`useGlossary`, `useCategories`) already short-circuit on `snapshot.empty`, so the mocked empty-snapshot return is consistent with their existing offline path.
- Production code (`src/firebase.js`) is unchanged.

## Before / after

- Before: `Test Files  2 failed | 8 passed (10)` — `925 passed`
- After:  `Test Files  10 passed (10)` — `952 passed` (27 previously-dead tests in App + ExploreBar now run)

## Test plan

- [x] `npm test` — all 952 tests pass across 10 suites
- [x] `npm run build` — production build succeeds
- [ ] Spot-check that the `App` smoke / dark-mode / WelcomeScreen tests and `ExploreBar` progress/category tests are actually exercising the components (no longer silently empty)

---
_Generated by [Claude Code](https://claude.ai/code/session_017gtGjHZ37GbyakzTQmBfh5)_