### PR TITLE
fix(firebase): guard analytics init when config is missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-glossary",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-glossary",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "firebase": "^12.12.0",
         "lucide-react": "^0.446.0",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,5 +13,8 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
-export const analytics = getAnalytics(app);
+// Analytics requires a real measurementId/projectId; skip it in environments
+// (tests, local dev without .env) where Firebase config isn't provided so the
+// module doesn't crash at import time.
+export const analytics = firebaseConfig.measurementId ? getAnalytics(app) : null;
 export const db = getFirestore(app);


### PR DESCRIPTION
## Summary

`getAnalytics(app)` was called eagerly at module load in `src/firebase.js`. When `VITE_FIREBASE_*` env vars aren't set (test env, local dev without `.env`), this threw `FirebaseError: Missing App configuration value: "projectId"` and cascaded to crash every test file that transitively imported `firebase.js`.

- `src/test/App.test.jsx` and `src/test/ExploreBar.test.jsx` failed to load entirely (0 tests ran from each).
- README claims "952 tests" — only 925 actually ran. After the fix, all 952 pass.

## Fix

Only call `getAnalytics(app)` when `firebaseConfig.measurementId` is provided. In production (where env vars are set), behavior is unchanged. `analytics` is exported but never consumed elsewhere in the codebase, so the null fallback is safe.

## Test plan

- [x] `npm test` → 952/952 tests pass
- [x] `npm run build` → builds cleanly


---
_Generated by [Claude Code](https://claude.ai/code/session_01YRokTzpAbnCgbMnJniiqYC)_