### PR TITLE
fix(firebase): skip analytics when projectId missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-glossary",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-glossary",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "firebase": "^12.12.0",
         "lucide-react": "^0.446.0",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,5 +13,7 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
-export const analytics = getAnalytics(app);
+// Analytics needs a real projectId — skip it when env vars are absent
+// (tests, local dev without .env) so it doesn't throw at module load.
+export const analytics = firebaseConfig.projectId ? getAnalytics(app) : null;
 export const db = getFirestore(app);


### PR DESCRIPTION
## Summary

Bug swept up during a scheduled bug check.

`src/firebase.js` calls `getAnalytics(app)` at module load. When `VITE_FIREBASE_*` env vars aren't set (test runs, env-less local dev), Firebase throws `Installations: Missing App configuration value: "projectId"` before any React code executes.

That was silently breaking the test suite: two files (`src/test/App.test.jsx` and `src/test/ExploreBar.test.jsx`) failed to collect because they transitively import `firebase.js` via `useGlossary` / `useCategories` / `ExploreBar`. Vitest reported them as failed suites with 0 tests inside — easy to miss unless you scroll the log.

Fix: guard the `getAnalytics` call behind a `projectId` truthiness check so tests boot cleanly. Production still initializes analytics normally, since the env vars are populated there.

## Before / after

- Before: `Test Files  2 failed | 8 passed (10)` — 925 passing tests, 2 suites failing to load.
- After: `Test Files  10 passed (10)` — 952 passing tests, no failures.

## Test plan

- [x] `npm test` — all 10 suites pass, 952 tests.
- [x] `npm run build` — production build succeeds.
- [ ] Verify analytics still initializes in the deployed site (`https://vibe-glossary.web.app`) after next deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaK8xUdvGJpDGmnbor5uph)_