### PR TITLE
chore: sync package-lock.json version to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-glossary",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-glossary",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "firebase": "^12.12.0",
         "lucide-react": "^0.446.0",


### PR DESCRIPTION
## Summary

- The lockfile's own `version` field was still on `0.7.0` while `package.json` is `0.8.1` — running `npm install` corrected it, so this commits that fix.
- Pure metadata sync. No dependencies were added, removed, or upgraded.

## Context

Ran the project locally to check for bugs (lint, tests, build). Everything else the branch touches is being investigated separately — this PR only contains the trivial lockfile bump so we can keep `package.json` and `package-lock.json` in agreement on the release version.

## Test plan

- [x] `git diff package-lock.json` shows only the two `version` lines change.
- [x] `npm install --legacy-peer-deps` no longer rewrites the lockfile on a clean checkout.
- [x] `npm run build` succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_015f7JVHQtejcyRgrG5KYqLQ)_