### PR TITLE
feat: class proof system, Design Language expansion, and vibe-prompting learning path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-17
+
+### Added
+- **Class proof system** for submitting learning progress as class work. Students open the score breakdown, click "Class proof", and copy a proof link or proof text for Canvas/LMS submissions. Instructors open the proof URL to see VibeScore, level, badges, date, and whether the class bar was met. No accounts required; proof is a base64url-encoded snapshot of the student's local progress
+- **Class bar**: reach Tinkerer (200 pts) OR earn the "Vibe prompting for UI" path badge
+- **"Vibe prompting for UI" learning path**: a cross-cluster class path pulling from Design Language, AI Literacy, and Web Foundations (15 topics, 5-question end-of-path quiz at 80%)
+- **5 new Design Language topics** from practical prompting rules: Color contrast and WCAG, Readable type (base size/line-height), Use existing tokens (design contract), One primary CTA per view, Brand is/is not constraints
+- **ProofView component** with live mode (generate proof) and verify mode (instructor opens link)
+- **Hash routing** for `#proof=...` URLs so proof links work as direct-open verification
+- **101 new tests** covering proof system, design language topic shape, and class path quiz validation (total: 1026 tests)
+
+### Changed
+- Design Language cluster expanded from 14 to 19 topics
+- Design Language path quiz updated with new topic questions (contrast, brand, CTA)
+- Build Literacy topic count updated from 105 to 110
+- Score breakdown modal now includes a "Class proof" button
+- Build path badge classification fixed to include cross-cluster paths (not just cluster-matched ids)
+- README updated with "For teachers" section explaining the class bar and proof workflow
+
 ## [0.8.1] - 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VibeGlossary
 
-A friendly UI + Build Literacy glossary for vibe coders. Browse 98 live component demos and 105 plain-language Build Literacy topics, generate AI prompts, take quizzes, and track learning with the VibeScore system.
+A friendly UI + Build Literacy glossary for vibe coders. Browse 98 live component demos and 110 plain-language Build Literacy topics, generate AI prompts, take quizzes, and track learning with the VibeScore system.
 
 ## Features
 
@@ -13,7 +13,7 @@ A friendly UI + Build Literacy glossary for vibe coders. Browse 98 live componen
 - **Long-form details accordion** — a one-line summary with an expandable beginner-friendly explanation for every entry
 
 ### Build Literacy
-- **105 topics across 7 clusters**: Web Foundations, Engineering, Auth & Security, Product, Design Language, Spec & Process, AI Literacy
+- **110 topics across 8 clusters**: Web Foundations, Engineering, Auth & Security, Product, Design Language, Spec & Process, AI Literacy
 - **Two-part Talk-to-AI prompts** — a generic starter that asks the AI to interview you, plus a practical example you can adapt
 - **Mnemonic for every topic** — the "if you remember nothing else" line
 - **Sibling Compare chips** and a Build Literacy Index for fast cross-topic learning
@@ -25,6 +25,8 @@ A friendly UI + Build Literacy glossary for vibe coders. Browse 98 live componen
 - **Learn Mode** for both surfaces — sibling compare pills, demo-to-definition quizzes, mastery tracking, and guided learning paths with end-of-path quizzes (80% to earn the badge)
 - **Score breakdown modal** — UI Glossary vs Build Literacy sub-scores, integrity rules in plain English
 - **Surprise Me** for both UI Glossary and Build Literacy
+- **Class proof** — students can generate a proof URL or copy proof text for Canvas/LMS submissions; instructors open the URL to verify VibeScore, level, badges, and whether the class bar was met
+- **"Vibe prompting for UI" class path** — a cross-cluster learning path covering Design Language, AI Literacy, and Web Foundations topics, designed for classroom assignments
 
 ### Sharing & UX
 - **Social share popover** — share your VibeScore, level, or path badge to X, LinkedIn, Bluesky, Facebook, Reddit, Email, or copy text + link. Falls back to `navigator.share` on mobile
@@ -44,7 +46,7 @@ A friendly UI + Build Literacy glossary for vibe coders. Browse 98 live componen
 - [Vite 5](https://vitejs.dev/)
 - [Tailwind CSS 3](https://tailwindcss.com/)
 - [Lucide React](https://lucide.dev/)
-- [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) (952 tests)
+- [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) (1026 tests)
 - [Firebase Hosting](https://firebase.google.com/products/hosting) + [Firestore](https://firebase.google.com/products/firestore)
 
 ## Getting Started
@@ -80,6 +82,7 @@ src/
 │   │                   # BuildPathsLauncher, BuildPathView
 │   │                   # TalkToAiCard, TopicTierBadge
 │   │                   # VibeScorePill, ScoreBreakdownModal, ShareAchievement
+│   │                   # ProofView
 │   ├── CheatSheet.jsx
 │   ├── WelcomeScreen.jsx
 │   └── demos/          # One file per UI Glossary component demo
@@ -99,14 +102,15 @@ src/
 ├── lib/
 │   ├── scoring.js            # Pure VibeScore math (POINTS, LEVELS, tiers)
 │   ├── quizIntegrity.js      # Time floor/ceiling, cooldowns, variant rotation
-│   └── share.js              # Share text + platform URL builders
+│   ├── share.js              # Share text + platform URL builders
+│   └── proof.js              # Class proof: bar check, snapshot, URL encode/decode
 ├── hooks/
 │   ├── useExploreMode.js     # Visited/used/attempts state + VibeScore + tiers
 │   ├── usePanelResize.js     # Drag-to-resize split panes (with persistence)
 │   ├── useGlossary.js        # Firestore-backed component reader
 │   └── useCategories.jsx     # Firestore-backed category reader
 ├── firebase.js               # Firebase app + Firestore init
-├── test/                     # Vitest test suite (952 tests)
+├── test/                     # Vitest test suite (1026 tests)
 ├── styles/
 │   └── animations.css
 ├── App.jsx
@@ -121,6 +125,21 @@ Deployed on [Firebase Hosting](https://vibe-glossary.web.app).
 npm run build
 firebase deploy --only hosting --project vibe-glossary
 ```
+
+## For teachers: assigning VibeGlossary as class work
+
+Students visit [vibe-glossary.web.app](https://vibe-glossary.web.app), explore topics, take quizzes, and earn badges. No account is needed; progress is stored in the browser.
+
+**Class bar (minimum for credit):** reach Tinkerer level (200 pts) OR earn the "Vibe prompting for UI" path badge (complete the path and pass the 5-question quiz at 80%).
+
+**How students submit proof:**
+
+1. Open the VibeScore breakdown (click the score pill in the top nav).
+2. Click "Class proof".
+3. Copy the proof link or proof text.
+4. Paste into Canvas, a Google Form, or whatever you use for submissions.
+
+**What you see as an instructor:** open the proof link in your browser. It shows the student's VibeScore, level, badges earned, date, and whether they met the class bar. The score is backed by quiz integrity checks (time floors, cooldowns, variant rotation) so it reflects genuine learning, not speedrunning.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-glossary",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Interactive UI component glossary for vibe coding with AI tools",
   "private": true,
   "type": "module",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import BuildLiteracyIndex from './components/learn/BuildLiteracyIndex';
 import BuildPathsLauncher from './components/learn/BuildPathsLauncher';
 import BuildPathView from './components/learn/BuildPathView';
 import ScoreBreakdownModal from './components/learn/ScoreBreakdownModal';
+import ProofView from './components/learn/ProofView';
 import TopicTierBadge from './components/learn/TopicTierBadge';
 import useExploreMode from './hooks/useExploreMode';
 import usePanelResize from './hooks/usePanelResize';
@@ -30,6 +31,7 @@ import {
   getBuildClusterColors,
 } from './data/buildLiteracy';
 import { DEMO_REGISTRY } from './data/demoRegistry';
+import { decodeProof } from './lib/proof';
 
 export default function App() {
   const [showWelcome, setShowWelcome] = useState(() => {
@@ -44,6 +46,8 @@ export default function App() {
   const [showBuildPaths, setShowBuildPaths] = useState(false);
   const [activeBuildPath, setActiveBuildPath] = useState(null);
   const [showScoreBreakdown, setShowScoreBreakdown] = useState(false);
+  const [showProof, setShowProof] = useState(false);
+  const [proofSnapshot, setProofSnapshot] = useState(null);
   const [activeItem, setActiveItem]       = useState('modal');
   const [activeBuildTopic, setActiveBuildTopic] = useState(() => BUILD_TOPIC_IDS[0] || 'mvp');
   const [siteSection, setSiteSection]     = useState('glossary'); // 'glossary' | 'build'
@@ -92,6 +96,25 @@ export default function App() {
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  // Handle #proof=... URLs so instructors can verify a student's proof
+  useEffect(() => {
+    function checkHash() {
+      const hash = window.location.hash;
+      const match = hash.match(/^#proof=(.+)$/);
+      if (match) {
+        const snap = decodeProof(match[1]);
+        if (snap) {
+          setProofSnapshot(snap);
+          setShowProof(true);
+          setShowWelcome(false);
+        }
+      }
+    }
+    checkHash();
+    window.addEventListener('hashchange', checkHash);
+    return () => window.removeEventListener('hashchange', checkHash);
   }, []);
 
   // Reset options when switching components & track visit
@@ -356,6 +379,16 @@ export default function App() {
         onClose={() => setShowScoreBreakdown(false)}
         score={explore.score}
         level={explore.level}
+        onOpenProof={() => { setShowScoreBreakdown(false); setProofSnapshot(null); setShowProof(true); }}
+      />
+
+      <ProofView
+        isOpen={showProof}
+        onClose={() => { setShowProof(false); setProofSnapshot(null); if (window.location.hash.startsWith('#proof=')) window.history.replaceState(null, '', window.location.pathname); }}
+        score={explore.score}
+        level={explore.level}
+        badges={explore.badges}
+        proofSnapshot={proofSnapshot}
       />
 
       {/* Top Navigation */}

--- a/src/components/learn/ProofView.jsx
+++ b/src/components/learn/ProofView.jsx
@@ -1,0 +1,287 @@
+import { useState, useMemo } from 'react';
+import {
+  Award, Check, X as CloseIcon, Copy, CheckCircle, ExternalLink,
+  Sparkles, GraduationCap, Shield, ShieldCheck, ShieldAlert,
+} from 'lucide-react';
+import { LEVELS, levelFor } from '../../lib/scoring';
+import {
+  classBar,
+  buildProofSnapshot,
+  buildProofUrl,
+  buildProofText,
+  CLASS_BAR_POINTS,
+  CLASS_PATH_ID,
+} from '../../lib/proof';
+import { copyToClipboard } from '../../lib/share';
+import ShareAchievement from './ShareAchievement';
+
+/**
+ * Two modes:
+ *
+ * 1. **Live proof** (proofSnapshot is null): reads the student's own local
+ *    progress and lets them generate + copy a proof URL / text.
+ *
+ * 2. **Verified proof** (proofSnapshot is provided): read-only card that an
+ *    instructor sees when they open a #proof=... URL. Shows the snapshot data
+ *    and whether the class bar was met.
+ */
+export default function ProofView({
+  isOpen,
+  onClose,
+  score,
+  level,
+  badges,
+  proofSnapshot = null,
+}) {
+  const [copiedUrl, setCopiedUrl] = useState(false);
+  const [copiedText, setCopiedText] = useState(false);
+
+  const isVerifyMode = !!proofSnapshot;
+
+  const liveSnapshot = useMemo(() => {
+    if (isVerifyMode) return null;
+    if (!score) return null;
+    return buildProofSnapshot({
+      score: score.total,
+      level,
+      badges,
+    });
+  }, [isVerifyMode, score, level, badges]);
+
+  const snapshot = proofSnapshot || liveSnapshot;
+
+  const proofUrl = useMemo(() => {
+    if (!snapshot) return '';
+    return buildProofUrl(snapshot);
+  }, [snapshot]);
+
+  const proofText = useMemo(() => {
+    if (!snapshot) return '';
+    return buildProofText({ snapshot, proofUrl });
+  }, [snapshot, proofUrl]);
+
+  const bar = useMemo(() => {
+    if (!snapshot) return { met: false, reasons: [] };
+    return classBar({
+      score: snapshot.s,
+      badges: new Set(snapshot.b || []),
+    });
+  }, [snapshot]);
+
+  const lvl = useMemo(() => {
+    if (!snapshot) return null;
+    return LEVELS.find(l => l.id === snapshot.l) || null;
+  }, [snapshot]);
+
+  const proofDate = useMemo(() => {
+    if (!snapshot?.d) return null;
+    return new Date(snapshot.d).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }, [snapshot]);
+
+  if (!isOpen) return null;
+
+  const handleBackdrop = (e) => { if (e.target === e.currentTarget) onClose(); };
+
+  async function handleCopyUrl() {
+    const ok = await copyToClipboard(proofUrl);
+    if (ok) { setCopiedUrl(true); setTimeout(() => setCopiedUrl(false), 2000); }
+  }
+
+  async function handleCopyText() {
+    const ok = await copyToClipboard(proofText);
+    if (ok) { setCopiedText(true); setTimeout(() => setCopiedText(false), 2000); }
+  }
+
+  return (
+    <div
+      onClick={handleBackdrop}
+      className="fixed inset-0 z-[200] bg-black/80 backdrop-blur-md flex items-center justify-center p-4 lg:p-8 animate-fade-in"
+    >
+      <div className="w-full max-w-lg max-h-[94vh] bg-white dark:bg-zinc-950 rounded-2xl shadow-2xl border border-zinc-200 dark:border-zinc-800 flex flex-col overflow-hidden">
+
+        {/* Header */}
+        <div className="shrink-0 flex items-start justify-between gap-3 px-5 lg:px-7 py-5 border-b border-zinc-200 dark:border-zinc-800">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className={`shrink-0 w-11 h-11 rounded-xl flex items-center justify-center shadow ${
+              bar.met
+                ? 'bg-gradient-to-br from-emerald-400 to-emerald-600'
+                : 'bg-gradient-to-br from-zinc-400 to-zinc-600'
+            }`}>
+              {bar.met ? <ShieldCheck size={22} className="text-white" /> : <Shield size={22} className="text-white" />}
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-xl lg:text-2xl font-extrabold tracking-tight text-zinc-900 dark:text-white">
+                {isVerifyMode ? 'Class Proof' : 'Your Class Proof'}
+              </h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                {isVerifyMode ? 'Submitted by a VibeGlossary learner' : 'Copy this to submit your work'}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+            aria-label="Close proof"
+          >
+            <CloseIcon size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-h-0 overflow-y-auto px-5 lg:px-7 py-5 space-y-5">
+
+          {/* Class bar status */}
+          <div className={`rounded-xl p-4 border ${
+            bar.met
+              ? 'border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40'
+              : 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40'
+          }`}>
+            <div className="flex items-center gap-2 mb-1">
+              {bar.met ? (
+                <CheckCircle size={18} className="text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <ShieldAlert size={18} className="text-amber-600 dark:text-amber-400" />
+              )}
+              <span className={`text-sm font-bold uppercase tracking-wider ${
+                bar.met
+                  ? 'text-emerald-700 dark:text-emerald-300'
+                  : 'text-amber-700 dark:text-amber-300'
+              }`}>
+                Class bar: {bar.met ? 'Met' : 'Not yet met'}
+              </span>
+            </div>
+            {bar.met ? (
+              <p className="text-sm text-emerald-700 dark:text-emerald-300 leading-snug">
+                {bar.reasons.join('. ')}.
+              </p>
+            ) : (
+              <p className="text-sm text-amber-700 dark:text-amber-300 leading-snug">
+                Reach Tinkerer ({CLASS_BAR_POINTS} pts) or complete the &quot;Vibe prompting for UI&quot; learning path.
+              </p>
+            )}
+          </div>
+
+          {/* Score card */}
+          <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+            <div className="px-4 py-3 bg-gradient-to-r from-amber-400 to-amber-600 text-white flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Sparkles size={18} />
+                <span className="text-base font-bold">VibeScore</span>
+              </div>
+              <span className="text-2xl font-extrabold tabular-nums">{snapshot?.s ?? 0}</span>
+            </div>
+            <div className="px-4 py-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-zinc-500 dark:text-zinc-400">Level</span>
+                <span className="text-sm font-bold text-zinc-900 dark:text-white">
+                  {lvl?.label || 'Lurker'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-zinc-500 dark:text-zinc-400">Badges earned</span>
+                <span className="text-sm font-bold text-zinc-900 dark:text-white">
+                  {(snapshot?.b || []).length}
+                </span>
+              </div>
+              {(snapshot?.b || []).length > 0 && (
+                <div className="flex flex-wrap gap-1.5 pt-1">
+                  {snapshot.b.map(id => (
+                    <span
+                      key={id}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-500/15 text-amber-700 dark:text-amber-300 text-xs font-semibold"
+                    >
+                      <Award size={12} /> {id}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {proofDate && (
+                <div className="flex items-center justify-between pt-1 border-t border-zinc-100 dark:border-zinc-800">
+                  <span className="text-sm text-zinc-500 dark:text-zinc-400">Date</span>
+                  <span className="text-sm font-bold text-zinc-900 dark:text-white">{proofDate}</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Level ladder */}
+          <div className="flex flex-wrap gap-1.5">
+            {LEVELS.map((l) => {
+              const reached = (snapshot?.s ?? 0) >= l.min;
+              const isCurrent = l.id === snapshot?.l;
+              return (
+                <span
+                  key={l.id}
+                  className={`px-2 py-0.5 rounded-full text-xs font-bold border transition-colors ${
+                    isCurrent
+                      ? 'bg-amber-500 text-white border-amber-500'
+                      : reached
+                        ? 'bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700/40'
+                        : 'bg-transparent text-zinc-400 dark:text-zinc-500 border-zinc-200 dark:border-zinc-700'
+                  }`}
+                >
+                  {l.label}
+                </span>
+              );
+            })}
+          </div>
+
+          {/* Actions: copy proof URL, copy proof text */}
+          {!isVerifyMode && (
+            <div className="space-y-2 pt-2 border-t border-zinc-200 dark:border-zinc-800">
+              <button
+                type="button"
+                onClick={handleCopyUrl}
+                className="flex items-center justify-center gap-2 w-full rounded-lg bg-gradient-to-br from-indigo-500 to-violet-600 hover:from-indigo-400 hover:to-violet-500 text-white text-sm font-bold px-4 py-2.5 transition-colors shadow-sm"
+              >
+                {copiedUrl ? (
+                  <><Check size={16} /> Proof link copied!</>
+                ) : (
+                  <><ExternalLink size={16} /> Copy proof link</>
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={handleCopyText}
+                className="flex items-center justify-center gap-2 w-full rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-200 text-sm font-semibold px-4 py-2.5 transition-colors"
+              >
+                {copiedText ? (
+                  <><Check size={16} className="text-emerald-500" /> Proof text copied!</>
+                ) : (
+                  <><Copy size={16} /> Copy proof text for Canvas</>
+                )}
+              </button>
+              <ShareAchievement
+                achievement={{
+                  kind: 'vibe-score',
+                  score: snapshot?.s ?? 0,
+                  level: lvl?.label || 'Lurker',
+                }}
+                variant="soft"
+                size="sm"
+                align="center"
+                label="Share on social"
+              />
+            </div>
+          )}
+
+          {/* Instructor note (verify mode only) */}
+          {isVerifyMode && (
+            <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60 p-4">
+              <p className="text-sm text-zinc-600 dark:text-zinc-300 leading-snug">
+                This proof was generated from the student&apos;s local learning progress
+                on VibeGlossary. Scores come from quizzes with integrity checks (time
+                floors, cooldowns, variant rotation). The class bar requires reaching
+                Tinkerer (200 pts) or completing the &quot;Vibe prompting for UI&quot; path badge.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/learn/ScoreBreakdownModal.jsx
+++ b/src/components/learn/ScoreBreakdownModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import {
   X, Sparkles, Eye, ClipboardCopy, GraduationCap, Award, Repeat, Trophy, Info,
+  ShieldCheck,
 } from 'lucide-react';
 import { POINTS, LEVELS } from '../../lib/scoring';
 import ShareAchievement from './ShareAchievement';
@@ -12,7 +13,7 @@ import ShareAchievement from './ShareAchievement';
  * make the deep-learning points visible: "1pt for visiting is small, 10pts
  * for mastering is big."
  */
-export default function ScoreBreakdownModal({ isOpen, onClose, score, level }) {
+export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onOpenProof }) {
   useEffect(() => {
     if (!isOpen) return;
     const onKey = (e) => { if (e.key === 'Escape') onClose(); };
@@ -53,6 +54,16 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level }) {
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            {onOpenProof && (
+              <button
+                type="button"
+                onClick={onOpenProof}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold bg-indigo-500/10 hover:bg-indigo-500/20 text-indigo-600 dark:text-indigo-300 border border-indigo-500/20 transition-colors"
+              >
+                <ShieldCheck size={14} />
+                Class proof
+              </button>
+            )}
             {total > 0 && (
               <ShareAchievement
                 achievement={{

--- a/src/data/buildLiteracy.js
+++ b/src/data/buildLiteracy.js
@@ -91,6 +91,12 @@ export const BUILD_CLUSTER_COLORS = {
     dot: 'bg-purple-500', accent: 'text-purple-500',
     gradient: 'from-purple-600 to-violet-700',
   },
+  'vibe-prompting': {
+    text: 'text-teal-400', bg: 'bg-teal-500/10', border: 'border-teal-500/30',
+    active: 'bg-teal-600 text-white', hover: 'hover:bg-teal-500/10',
+    dot: 'bg-teal-500', accent: 'text-teal-500',
+    gradient: 'from-teal-500 to-cyan-600',
+  },
 };
 
 export function getBuildClusterColors(clusterId) {

--- a/src/data/buildPaths.js
+++ b/src/data/buildPaths.js
@@ -52,9 +52,9 @@ export const BUILD_PATHS = [
   {
     id: 'design-language',
     name: 'Design language',
-    tagline: 'Tokens, scales, states, variants: the words designers use',
+    tagline: 'Tokens, scales, states, variants, contrast, brand: the words designers use',
     description:
-      'Design systems vs component libraries, tokens, typography and spacing scales, color palettes, component states, variants and sizes, density, elevation, radius, motion, fidelity, atomic design, breakpoints. The vocabulary that lets you ask an AI for "the secondary button at md size" instead of "make it look better".',
+      'Design systems vs component libraries, tokens, typography and spacing scales, color palettes, component states, variants and sizes, density, elevation, radius, motion, fidelity, atomic design, breakpoints, WCAG contrast, readable type, the design contract, CTA hierarchy, and brand constraints. The vocabulary that lets you ask an AI for "the secondary button at md size with WCAG AA contrast" instead of "make it look better".',
     quiz: [
       {
         q: 'A named value like "color.primary.500" or "space.4" that stands in for a hard-coded value is a...',
@@ -62,9 +62,9 @@ export const BUILD_PATHS = [
         optionIds: ['design-tokens', 'design-system', 'color-palette', 'spacing-scale'],
       },
       {
-        q: 'Picking 5-8 fixed font sizes and never inventing a one-off is using a...',
-        answerId: 'typography-scale',
-        optionIds: ['typography-scale', 'spacing-scale', 'design-tokens', 'border-radius'],
+        q: 'The minimum contrast ratio WCAG AA requires for normal-size body text is...',
+        answerId: 'contrast-wcag',
+        optionIds: ['contrast-wcag', 'color-palette', 'readable-type', 'design-tokens'],
       },
       {
         q: 'The state most often skipped, the one that breaks accessibility, is the...',
@@ -72,14 +72,14 @@ export const BUILD_PATHS = [
         optionIds: ['component-states', 'variants-sizes', 'density', 'motion'],
       },
       {
-        q: 'A single Button component with `variant="ghost"` and `size="sm"` props is using...',
-        answerId: 'variants-sizes',
-        optionIds: ['variants-sizes', 'design-system', 'atomic-design', 'density'],
+        q: 'A short list of "we are X, not Y" pairs that tells an AI your product personality is a...',
+        answerId: 'brand-constraints',
+        optionIds: ['brand-constraints', 'design-system', 'one-primary-cta', 'design-tokens'],
       },
       {
-        q: 'Writing styles for the smallest screen first and adding `md:` and `lg:` rules on top is...',
-        answerId: 'responsive-breakpoints',
-        optionIds: ['responsive-breakpoints', 'density', 'atomic-design', 'fidelity'],
+        q: 'Every screen should have exactly one loud, filled button for the main action. That button is the...',
+        answerId: 'one-primary-cta',
+        optionIds: ['one-primary-cta', 'variants-sizes', 'component-states', 'brand-constraints'],
       },
     ],
   },
@@ -287,11 +287,64 @@ export const BUILD_PATHS = [
       },
     ],
   },
+  {
+    id: 'vibe-prompting',
+    name: 'Vibe prompting for UI',
+    tagline: 'Learn to talk to an AI about UI so you can ship',
+    description:
+      'A class-ready path that covers the vocabulary and prompting skills you need to describe a user interface to an AI and get back something you would actually ship. Pulls from Design Language, AI Literacy, and Web Foundations so you learn the words, the tools, and the building blocks together.',
+    isCrossCluster: true,
+    items: [
+      'prompts-roles',
+      'design-system',
+      'design-tokens',
+      'typography-scale',
+      'readable-type',
+      'contrast-wcag',
+      'color-palette',
+      'one-primary-cta',
+      'brand-constraints',
+      'design-contract',
+      'component-states',
+      'responsive-breakpoints',
+      'llm',
+      'tokens',
+      'tool-calling',
+    ],
+    quiz: [
+      {
+        q: 'Putting format rules in the system message (not the user message) so they stick better is using the...',
+        answerId: 'prompts-roles',
+        optionIds: ['prompts-roles', 'llm', 'tokens', 'sampling'],
+      },
+      {
+        q: 'The minimum contrast ratio WCAG AA requires for normal-size body text is...',
+        answerId: 'contrast-wcag',
+        optionIds: ['contrast-wcag', 'color-palette', 'readable-type', 'design-tokens'],
+      },
+      {
+        q: 'A short "we are X, not Y" list you paste into a system prompt to steer the AI toward your brand is a...',
+        answerId: 'brand-constraints',
+        optionIds: ['brand-constraints', 'design-system', 'design-tokens', 'one-primary-cta'],
+      },
+      {
+        q: 'Telling the AI "use only the tokens in tailwind.config.js" instead of letting it invent arbitrary values is enforcing the...',
+        answerId: 'design-contract',
+        optionIds: ['design-contract', 'design-tokens', 'design-system', 'typography-scale'],
+      },
+      {
+        q: 'Every screen should have exactly one loud, filled button for the main action. That principle is called...',
+        answerId: 'one-primary-cta',
+        optionIds: ['one-primary-cta', 'component-states', 'variants-sizes', 'brand-constraints'],
+      },
+    ],
+  },
 ];
 
 // Inject the topic ids from each matching cluster into path.items so the path
 // stays in sync with the data (no need to repeat ids by hand).
 for (const path of BUILD_PATHS) {
+  if (path.isCrossCluster) continue;
   const cluster = BUILD_LITERACY_CLUSTERS.find(c => c.id === path.id);
   path.items = cluster ? cluster.topics.map(t => t.id) : [];
 }

--- a/src/data/designLanguage.js
+++ b/src/data/designLanguage.js
@@ -317,5 +317,110 @@ export const DESIGN_LANGUAGE_CLUSTER = {
         'Mobile-first: write the small layout, add bigger rules on top. Touch targets at least 44 by 44.',
       relatedGlossaryIds: ['appshell', 'card', 'pricing'],
     },
+    {
+      id: 'contrast-wcag',
+      title: 'Color contrast and WCAG',
+      summary:
+        'Every text/background pair needs enough contrast for people to read it. WCAG (Web Content Accessibility Guidelines) sets the bar: at least 4.5:1 for body text, 3:1 for large text. "Make it pop" is not a contrast ratio.',
+      details:
+        'Contrast ratio is a number that describes how far apart two colors are in lightness. White text on a white background is 1:1 (invisible). Black text on a white background is 21:1 (maximum). WCAG AA, the standard almost every product should meet, requires 4.5:1 for normal-size text and 3:1 for text that is at least 18pt (or 14pt bold). WCAG AAA raises those to 7:1 and 4.5:1, which is harder to hit with brand colors but great for long-form reading.\n\nThe most common failures are light gray text on white, colored text on a colored background, and text over images without an overlay. Tools like the WebAIM Contrast Checker, Figma plugins like Stark, and browser DevTools (Inspect, Accessibility tab) all show the ratio instantly. Tailwind does not enforce contrast on its own, so you need to check.\n\nWhen you are prompting an AI, the words "meet WCAG AA contrast" are worth more than "make sure people can read it". The AI knows the spec and will pick colors that pass. Without the spec name, it guesses, and light-gray-on-white keeps showing up.',
+      comparison:
+        'AA = 4.5:1 for body text, 3:1 for large text. AAA = 7:1 and 4.5:1. Ratio, not vibes.',
+      vibeTip:
+        'Always say "WCAG AA contrast" in your prompt. The AI knows the numbers and will pick passing colors instead of guessing "readable enough".',
+      talkToAi: {
+        starter:
+          'Audit color contrast across [project or page]. Before changing anything, ask me: 1) the pages or components to check, 2) whether we target WCAG AA or AAA, 3) whether dark mode needs its own audit. Then list every text/background pair that fails, show the current ratio vs the required ratio, and propose replacement colors that pass while staying close to our palette.',
+        example:
+          'Audit contrast on the landing page. Target WCAG AA. Check both light and dark mode. List every failing pair, show the ratio, and suggest the closest passing color from our Tailwind palette.',
+      },
+      mnemonic:
+        '4.5:1 for body text, 3:1 for large text. Say "WCAG AA" and the AI handles the math.',
+      relatedGlossaryIds: ['badge', 'button'],
+    },
+    {
+      id: 'readable-type',
+      title: 'Readable type: base size, line-height, do not shrink body text',
+      summary:
+        'Body text should be at least 16px (1rem). Line-height for paragraphs should be 1.4 to 1.6. Shrinking body text below 14px to fit more on screen trades readability for density, and readability always wins.',
+      details:
+        'Three rules cover 90% of type readability. First, set a base size of at least 16px (Tailwind text-base). Browsers default to 16px for a reason: it is the smallest size most people can read comfortably on a phone at arm\'s length. Going to 14px (text-sm) for secondary labels and metadata is fine. Going below that for body paragraphs is not.\n\nSecond, set line-height (the vertical space between lines, sometimes called "leading") to 1.4 to 1.6 for body copy. Tailwind\'s text-base ships with leading-6 (1.5), which is right in the sweet spot. Headings can be tighter (1.1 to 1.3) because they are short and big. Code blocks can be tighter too (1.4).\n\nThird, ask for a type scale instead of picking sizes ad hoc. A scale is a small ladder of sizes (like Tailwind\'s xs, sm, base, lg, xl, 2xl) with line-heights already paired. When you tell an AI "use a type scale with a 16px base, 1.5 line-height for body, and 1.2 for headings", it stops inventing text-[13px] or leading-[17px] on every component.',
+      comparison:
+        'Body at 16px with 1.5 line-height = comfortable. Body at 12px with 1.2 line-height = squinting. Use the scale, not one-off sizes.',
+      vibeTip:
+        'Tell your AI "body text must be at least text-sm (14px), prefer text-base (16px), line-height 1.5". It stops shrinking text to fit layouts.',
+      talkToAi: {
+        starter:
+          'Set up readable typography for [project]. Before suggesting anything, ask me: 1) the type of content (long articles, dashboards, marketing pages), 2) the smallest text we allow (captions, footnotes), 3) the font family (or "pick one"), 4) whether we need a code font. Then propose a scale (xs through 2xl) with base size, line-heights for each use (body, heading, code, label), and show an example paragraph at each rung so I can feel the difference.',
+        example:
+          'Set up readable typography for a learning site with long explanations. Inter for body, minimum text size is text-xs for fine print only. Paragraphs use text-base/leading-relaxed. Headings use text-xl through text-3xl with tight leading. Show an example card with a heading, a two-paragraph body, and a caption.',
+      },
+      mnemonic:
+        '16px base, 1.5 line-height, never shrink body text. Read it on your phone before you ship.',
+      relatedGlossaryIds: ['hero', 'card'],
+    },
+    {
+      id: 'design-contract',
+      title: 'Use the tokens that already exist: do not invent new ones',
+      summary:
+        'If your design system (or Tailwind config) already has names for colors, spacing, and radii, use those names. Inventing new values ("just this once, 13px") breaks the contract that makes everything consistent.',
+      details:
+        'A design contract is the agreement that everyone (including the AI) uses the same named values. When a Tailwind config says primary-500 is #4F46E5 and spacing goes in 4px steps, those are the contract. Every component built on those tokens looks like it belongs.\n\nThe contract breaks when someone introduces a value that is not in the system. A "gap-[13px]" here, a "#5B21B6" there, a "rounded-[7px]" somewhere else. Each one is small. Together they make the product feel like five different designers worked on it without talking to each other.\n\nThe fix is simple: before adding a new value, check whether the system already has one close enough. If spacing-3 (12px) or spacing-4 (16px) exists, do not invent 13px. If the system truly needs a new token, add it to the config so everyone gets it, do not hard-code it in one component. When prompting an AI, the phrase "use only existing tokens from our config" stops it from inventing arbitrary values on every generation.',
+      comparison:
+        'Using existing tokens = cohesion. Inventing values = drift. If you need a new value, add it to the system, not inline.',
+      vibeTip:
+        'Tell your AI "use only the tokens in tailwind.config.js, do not add arbitrary values". It stops generating px overrides that drift from the system.',
+      talkToAi: {
+        starter:
+          'Audit [component or page] for off-system values. Before changing anything, ask me: 1) where the design tokens live (tailwind.config.js, CSS variables, a tokens file), 2) which categories to audit (color, spacing, radius, shadow, font), 3) whether I want you to fix or just report. Then list every hard-coded or arbitrary value, show what system token it should use instead, and flag any case where no close token exists (those might need a new token added to the config).',
+        example:
+          'Audit src/components/Card.tsx for off-system values. Our tokens are in tailwind.config.js. Report every arbitrary value (gap-[13px], text-[#333], rounded-[5px]) and replace each with the closest Tailwind default. If nothing is close, propose a new token.',
+      },
+      mnemonic:
+        'If the system has a name for it, use the name. If it does not, add one. Never hard-code in one place.',
+      relatedGlossaryIds: ['card', 'button'],
+    },
+    {
+      id: 'one-primary-cta',
+      title: 'One primary call to action per view',
+      summary:
+        'Every screen should have one obvious "do this next" button. If three buttons are all loud and colorful, none of them stands out, and the user freezes. Primary is for the main action. Everything else is secondary, ghost, or a link.',
+      details:
+        'A call to action (CTA) is the button (or link) you most want the user to press. "Sign up", "Save", "Submit order", "Start free trial". Making it primary means giving it the strongest visual treatment: filled with the brand color, large enough to find instantly, and usually positioned at the bottom or top-right of the form.\n\nThe mistake is making everything primary. When the "Save" button, the "Cancel" button, and the "Delete account" link are all big, bright, and filled, the user has to read every label to figure out which one to press. That cognitive load (the tiny pause while they parse labels) is the difference between a product that feels fast and one that feels uncertain.\n\nThe hierarchy: one primary button (the action you want), one or two secondary buttons (alternatives like "Cancel" or "Save as draft"), and everything else as ghost or text links. Destructive actions (delete, disconnect, revoke) get a destructive variant (red/danger) but should still be visually quieter than the primary unless the whole screen exists to confirm a delete.',
+      comparison:
+        'One primary = clear next step. Three primaries = decision fatigue. Use secondary, ghost, or link for the rest.',
+      vibeTip:
+        'Tell your AI "one primary CTA per view, secondary for alternatives, ghost or link for the rest". It stops painting every button in brand purple.',
+      talkToAi: {
+        starter:
+          'Audit the button hierarchy on [page or form]. Before changing anything, ask me: 1) the main action the user should take, 2) the secondary actions (save draft, cancel, go back), 3) any destructive actions (delete, disconnect). Then propose which button gets primary, which gets secondary, and which gets ghost or link treatment. Show the updated layout with Tailwind classes.',
+        example:
+          'Audit the checkout page. Main action: "Place order" (primary). Secondary: "Back to cart" (ghost). Destructive: "Remove item" (small ghost text, not a big button). Update the JSX with the right variant classes.',
+      },
+      mnemonic:
+        'One loud button per screen. If everything is primary, nothing is.',
+      relatedGlossaryIds: ['button', 'hero'],
+    },
+    {
+      id: 'brand-constraints',
+      title: 'Brand is / is not: giving an AI taste without a 20-page brand book',
+      summary:
+        'A short "brand is / is not" list tells the AI the personality of your product in a few lines. "We are calm and confident, not playful or loud." That single sentence steers color, typography, copy tone, and illustration style better than a 50-slide deck the AI cannot read.',
+      details:
+        'Most projects do not have a brand book, and you do not need one to give an AI useful taste constraints. A brand is/is not list is a handful of pairs that describe what the product should feel like and what it should not. "Calm, not sterile. Confident, not aggressive. Friendly, not childish. Technical, not intimidating." Each pair narrows the design space so the AI picks appropriate options instead of defaulting to generic.\n\nThe list works because it is short enough to paste into a system prompt and specific enough to resolve ambiguity. When an AI picks a font, "friendly but not childish" steers it toward Inter or DM Sans and away from Comic Sans or Papyrus. When it picks colors, "calm and confident" steers it toward muted blues and neutrals, not neon gradients.\n\nYou can extend the pattern with a few concrete references: "Think Linear, not MySpace. Think Stripe, not a county fair poster." Product references are the fastest shorthand because the AI already knows what those products look like. Three constraints and two references give the AI more useful guidance than a brand deck it was not trained on.',
+      comparison:
+        'Brand book = 50 pages the AI cannot read. Is/is-not list = 5 lines that fit in a system prompt and actually steer output.',
+      vibeTip:
+        'Put your "brand is / is not" list and 2 to 3 product references in the system prompt of every design conversation. The AI will stay on-brand without a Figma file.',
+      talkToAi: {
+        starter:
+          'Help me write a brand is/is not list for [project]. Before suggesting anything, ask me: 1) what the product does in one sentence, 2) the audience (developers, consumers, enterprise, students), 3) two or three products whose vibe I admire, 4) anything I definitely do NOT want (playful, corporate, dark, loud). Then propose 4 to 6 is/is-not pairs with a short explanation of how each one would affect color, type, and tone. Include 2 to 3 product references I can paste into AI prompts.',
+        example:
+          'Write a brand is/is not list for a developer documentation site. Audience: intermediate developers. I admire the tone of Stripe Docs and Linear. I do not want corporate or playful. Propose is/is-not pairs and show how they map to Tailwind choices (palette, font, radius).',
+      },
+      mnemonic:
+        'Five lines of "we are X, not Y" steer an AI better than a brand book it cannot open.',
+      relatedGlossaryIds: ['hero', 'card'],
+    },
   ],
 };

--- a/src/hooks/useExploreMode.js
+++ b/src/hooks/useExploreMode.js
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useEffect } from 'react';
 import { CATEGORIES } from '../data/categories';
 import { buildTiers, vibeScore, levelFor } from '../lib/scoring';
 import { newSessionId } from '../lib/quizIntegrity';
+import { BUILD_PATH_IDS } from '../data/buildPaths';
 
 const STORAGE_KEY = 'vg-explored';
 const COPIED_KEY = 'vg-copied';
@@ -248,6 +249,7 @@ export default function useExploreMode(categories = CATEGORIES, buildClusters = 
   // cluster id; otherwise it is a glossary path. (Matches buildPaths.js.)
   const buildPathIdSet = useMemo(() => {
     const set = new Set(buildClusters.map(c => c.id));
+    BUILD_PATH_IDS.forEach(id => set.add(id));
     return set;
   }, [buildClusters]);
 

--- a/src/lib/proof.js
+++ b/src/lib/proof.js
@@ -1,0 +1,131 @@
+/**
+ * Class proof helpers.
+ *
+ * A student can share a proof URL that encodes their VibeScore, level, badges,
+ * and whether they met the class bar. An instructor opens the link and sees a
+ * read-only proof card. No backend, no accounts.
+ *
+ * The class bar (the minimum an instructor should expect):
+ *   - Reach Tinkerer (200 pts), OR
+ *   - Complete the "Vibe prompting for UI" learning path (earn the badge).
+ *
+ * Everything here is pure (no React, no DOM, no localStorage).
+ */
+
+import { LEVELS, levelFor } from './scoring.js';
+
+export const CLASS_PATH_ID = 'vibe-prompting';
+export const CLASS_BAR_LEVEL_ID = 'tinkerer';
+export const CLASS_BAR_POINTS = LEVELS.find(l => l.id === CLASS_BAR_LEVEL_ID)?.min ?? 200;
+
+/**
+ * Does the student meet the class bar?
+ *
+ * Returns { met: bool, reasons: string[] }.
+ * `reasons` lists each criterion that passed (useful for proof text).
+ */
+export function classBar({ score = 0, badges = new Set() } = {}) {
+  const reasons = [];
+  const level = levelFor(score);
+
+  if (score >= CLASS_BAR_POINTS) {
+    reasons.push(`Reached ${level.current.label} (${score} pts)`);
+  }
+  if (badges.has(CLASS_PATH_ID)) {
+    reasons.push('Completed "Vibe prompting for UI" path');
+  }
+
+  return { met: reasons.length > 0, reasons };
+}
+
+/**
+ * Build a compact proof snapshot that can round-trip through a URL hash.
+ *
+ * Shape: { s, l, b, d, v }
+ *   s = score (number)
+ *   l = level id (string)
+ *   b = array of earned badge ids
+ *   d = ISO date string
+ *   v = format version (for future-proofing)
+ */
+export function buildProofSnapshot({ score = 0, level, badges = new Set() } = {}) {
+  const lvl = level || levelFor(score);
+  return {
+    v: 1,
+    s: score,
+    l: lvl.current.id,
+    b: [...badges],
+    d: new Date().toISOString(),
+  };
+}
+
+/**
+ * Encode a proof snapshot into a URL-safe string (base64url of JSON).
+ */
+export function encodeProof(snapshot) {
+  const json = JSON.stringify(snapshot);
+  if (typeof btoa === 'function') {
+    return btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  return Buffer.from(json).toString('base64url');
+}
+
+/**
+ * Decode a proof string back into a snapshot. Returns null on failure.
+ */
+export function decodeProof(encoded) {
+  try {
+    let b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) b64 += '=';
+    const json = typeof atob === 'function'
+      ? atob(b64)
+      : Buffer.from(b64, 'base64').toString('utf-8');
+    const obj = JSON.parse(json);
+    if (typeof obj.s !== 'number' || typeof obj.l !== 'string') return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the full proof URL from a snapshot.
+ */
+export function buildProofUrl(snapshot, origin) {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : 'https://vibe-glossary.web.app');
+  return `${base}/#proof=${encodeProof(snapshot)}`;
+}
+
+/**
+ * Build human-readable proof text suitable for pasting into Canvas, a form,
+ * or an email. Includes the proof URL so the instructor can verify.
+ */
+export function buildProofText({ snapshot, proofUrl } = {}) {
+  if (!snapshot) return '';
+  const lvl = LEVELS.find(l => l.id === snapshot.l);
+  const levelLabel = lvl ? lvl.label : snapshot.l;
+  const bar = classBar({ score: snapshot.s, badges: new Set(snapshot.b || []) });
+  const date = snapshot.d ? new Date(snapshot.d).toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric',
+  }) : 'unknown date';
+
+  const lines = [
+    'VibeGlossary Class Proof',
+    '========================',
+    `VibeScore: ${snapshot.s}`,
+    `Level: ${levelLabel}`,
+    `Badges earned: ${(snapshot.b || []).length > 0 ? snapshot.b.join(', ') : 'none'}`,
+    `Date: ${date}`,
+    `Class bar: ${bar.met ? 'MET' : 'NOT MET'}`,
+  ];
+
+  if (bar.met && bar.reasons.length) {
+    lines.push(`Criteria: ${bar.reasons.join('; ')}`);
+  }
+
+  if (proofUrl) {
+    lines.push('', `Verify: ${proofUrl}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/test/designLanguage.test.js
+++ b/src/test/designLanguage.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { DESIGN_LANGUAGE_CLUSTER } from '../data/designLanguage';
+import { BUILD_PATHS } from '../data/buildPaths';
+import {
+  BUILD_LITERACY_CLUSTERS,
+  getBuildTopic,
+} from '../data/buildLiteracy';
+
+const topics = DESIGN_LANGUAGE_CLUSTER.topics;
+
+describe('DESIGN_LANGUAGE_CLUSTER', () => {
+  it('has a non-empty id and title', () => {
+    expect(DESIGN_LANGUAGE_CLUSTER.id).toBe('design-language');
+    expect(DESIGN_LANGUAGE_CLUSTER.title.length).toBeGreaterThan(0);
+  });
+
+  it('has at least 18 topics (13 original + 5 new)', () => {
+    expect(topics.length).toBeGreaterThanOrEqual(18);
+  });
+
+  it('has unique topic ids', () => {
+    const ids = topics.map(t => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('Design Language topic shape', () => {
+  describe.each(topics.map(t => [t.id, t]))('%s', (_id, topic) => {
+    it('has all required fields', () => {
+      expect(typeof topic.id).toBe('string');
+      expect(typeof topic.title).toBe('string');
+      expect(typeof topic.summary).toBe('string');
+      expect(typeof topic.details).toBe('string');
+      expect(typeof topic.comparison).toBe('string');
+      expect(typeof topic.vibeTip).toBe('string');
+      expect(typeof topic.mnemonic).toBe('string');
+      expect(topic.talkToAi).toBeDefined();
+      expect(typeof topic.talkToAi.starter).toBe('string');
+      expect(typeof topic.talkToAi.example).toBe('string');
+      expect(Array.isArray(topic.relatedGlossaryIds)).toBe(true);
+    });
+
+    it('has non-empty required strings', () => {
+      expect(topic.title.trim().length).toBeGreaterThan(0);
+      expect(topic.summary.trim().length).toBeGreaterThan(0);
+      expect(topic.details.trim().length).toBeGreaterThan(0);
+      expect(topic.comparison.trim().length).toBeGreaterThan(0);
+      expect(topic.vibeTip.trim().length).toBeGreaterThan(0);
+      expect(topic.mnemonic.trim().length).toBeGreaterThan(0);
+      expect(topic.talkToAi.starter.trim().length).toBeGreaterThan(0);
+      expect(topic.talkToAi.example.trim().length).toBeGreaterThan(0);
+    });
+
+    it('contains no em dashes in student-facing copy', () => {
+      const fields = [topic.summary, topic.details, topic.comparison, topic.vibeTip, topic.mnemonic, topic.talkToAi.starter, topic.talkToAi.example];
+      for (const f of fields) {
+        expect(f).not.toContain('\u2014');
+        expect(f).not.toContain('\u2013');
+      }
+    });
+  });
+});
+
+describe('New topics exist', () => {
+  const newTopicIds = ['contrast-wcag', 'readable-type', 'design-contract', 'one-primary-cta', 'brand-constraints'];
+
+  it.each(newTopicIds)('%s is present in the cluster', (id) => {
+    expect(topics.find(t => t.id === id)).toBeDefined();
+  });
+
+  it.each(newTopicIds)('%s is resolvable via getBuildTopic', (id) => {
+    expect(getBuildTopic(id)).not.toBeNull();
+    expect(getBuildTopic(id).clusterId).toBe('design-language');
+  });
+});
+
+describe('design-language path quiz', () => {
+  const path = BUILD_PATHS.find(p => p.id === 'design-language');
+
+  it('exists', () => {
+    expect(path).toBeDefined();
+  });
+
+  it('has 5 quiz questions', () => {
+    expect(path.quiz).toHaveLength(5);
+  });
+
+  it('every answerId resolves to a known build topic', () => {
+    for (const q of path.quiz) {
+      expect(getBuildTopic(q.answerId)).not.toBeNull();
+    }
+  });
+
+  it('every optionId resolves to a known build topic', () => {
+    for (const q of path.quiz) {
+      for (const optId of q.optionIds) {
+        expect(getBuildTopic(optId)).not.toBeNull();
+      }
+    }
+  });
+});
+
+describe('vibe-prompting class path', () => {
+  const path = BUILD_PATHS.find(p => p.id === 'vibe-prompting');
+
+  it('exists', () => {
+    expect(path).toBeDefined();
+  });
+
+  it('has isCrossCluster set to true', () => {
+    expect(path.isCrossCluster).toBe(true);
+  });
+
+  it('has items spanning multiple clusters', () => {
+    const clusterIds = new Set(
+      path.items.map(id => getBuildTopic(id)?.clusterId).filter(Boolean)
+    );
+    expect(clusterIds.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every item resolves to a known build topic', () => {
+    for (const id of path.items) {
+      expect(getBuildTopic(id)).not.toBeNull();
+    }
+  });
+
+  it('has 5 quiz questions', () => {
+    expect(path.quiz).toHaveLength(5);
+  });
+
+  it('every quiz answerId resolves to a known build topic', () => {
+    for (const q of path.quiz) {
+      expect(getBuildTopic(q.answerId)).not.toBeNull();
+    }
+  });
+
+  it('every quiz optionId resolves to a known build topic', () => {
+    for (const q of path.quiz) {
+      for (const optId of q.optionIds) {
+        expect(getBuildTopic(optId)).not.toBeNull();
+      }
+    }
+  });
+});

--- a/src/test/proof.test.js
+++ b/src/test/proof.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classBar,
+  buildProofSnapshot,
+  encodeProof,
+  decodeProof,
+  buildProofUrl,
+  buildProofText,
+  CLASS_BAR_POINTS,
+  CLASS_PATH_ID,
+} from '../lib/proof';
+
+describe('classBar', () => {
+  it('is not met with zero score and no badges', () => {
+    const result = classBar({ score: 0, badges: new Set() });
+    expect(result.met).toBe(false);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it('is met when score reaches Tinkerer threshold', () => {
+    const result = classBar({ score: CLASS_BAR_POINTS, badges: new Set() });
+    expect(result.met).toBe(true);
+    expect(result.reasons.length).toBeGreaterThan(0);
+    expect(result.reasons[0]).toContain('Tinkerer');
+  });
+
+  it('is met when score exceeds Tinkerer threshold', () => {
+    const result = classBar({ score: 500, badges: new Set() });
+    expect(result.met).toBe(true);
+    expect(result.reasons[0]).toContain('Shipper');
+  });
+
+  it('is met when class path badge is earned even with low score', () => {
+    const result = classBar({ score: 10, badges: new Set([CLASS_PATH_ID]) });
+    expect(result.met).toBe(true);
+    expect(result.reasons.some(r => r.includes('Vibe prompting'))).toBe(true);
+  });
+
+  it('is met with both criteria (two reasons)', () => {
+    const result = classBar({ score: 300, badges: new Set([CLASS_PATH_ID]) });
+    expect(result.met).toBe(true);
+    expect(result.reasons).toHaveLength(2);
+  });
+
+  it('is not met at 199 pts without the class path badge', () => {
+    const result = classBar({ score: 199, badges: new Set() });
+    expect(result.met).toBe(false);
+  });
+
+  it('defaults safely when called with no arguments', () => {
+    const result = classBar();
+    expect(result.met).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+});
+
+describe('buildProofSnapshot', () => {
+  it('produces a snapshot with the expected shape', () => {
+    const snap = buildProofSnapshot({
+      score: 250,
+      badges: new Set(['design-language', 'vibe-prompting']),
+    });
+    expect(snap.v).toBe(1);
+    expect(snap.s).toBe(250);
+    expect(snap.l).toBe('tinkerer');
+    expect(snap.b).toEqual(expect.arrayContaining(['design-language', 'vibe-prompting']));
+    expect(snap.d).toBeTruthy();
+  });
+
+  it('defaults to lurker with zero score', () => {
+    const snap = buildProofSnapshot({ score: 0 });
+    expect(snap.l).toBe('lurker');
+    expect(snap.b).toEqual([]);
+  });
+});
+
+describe('encodeProof / decodeProof', () => {
+  it('round-trips a snapshot through encode and decode', () => {
+    const original = {
+      v: 1,
+      s: 200,
+      l: 'tinkerer',
+      b: ['design-language'],
+      d: '2026-08-15T00:00:00.000Z',
+    };
+    const encoded = encodeProof(original);
+    expect(typeof encoded).toBe('string');
+    expect(encoded.length).toBeGreaterThan(0);
+
+    const decoded = decodeProof(encoded);
+    expect(decoded).toEqual(original);
+  });
+
+  it('produces URL-safe characters (no +, /, or =)', () => {
+    const encoded = encodeProof({ v: 1, s: 999, l: 'vibe-coder', b: ['a', 'b', 'c'], d: new Date().toISOString() });
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+
+  it('returns null for garbage input', () => {
+    expect(decodeProof('not-valid-base64!!!')).toBeNull();
+  });
+
+  it('returns null for valid base64 but invalid JSON', () => {
+    const fakeB64 = btoa('this is not json').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(decodeProof(fakeB64)).toBeNull();
+  });
+
+  it('returns null for JSON missing required fields', () => {
+    const noScore = btoa(JSON.stringify({ v: 1, l: 'lurker' })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(decodeProof(noScore)).toBeNull();
+  });
+});
+
+describe('buildProofUrl', () => {
+  it('builds a URL with #proof= hash', () => {
+    const snap = { v: 1, s: 200, l: 'tinkerer', b: [], d: '2026-08-15T00:00:00.000Z' };
+    const url = buildProofUrl(snap, 'https://vibe-glossary.web.app');
+    expect(url).toMatch(/^https:\/\/vibe-glossary\.web\.app\/#proof=/);
+  });
+
+  it('the encoded part decodes back to the snapshot', () => {
+    const snap = { v: 1, s: 200, l: 'tinkerer', b: ['vibe-prompting'], d: '2026-08-15T00:00:00.000Z' };
+    const url = buildProofUrl(snap, 'https://example.com');
+    const encoded = url.split('#proof=')[1];
+    expect(decodeProof(encoded)).toEqual(snap);
+  });
+});
+
+describe('buildProofText', () => {
+  it('includes all required proof fields', () => {
+    const snap = { v: 1, s: 250, l: 'tinkerer', b: ['design-language'], d: '2026-08-15T00:00:00.000Z' };
+    const text = buildProofText({ snapshot: snap, proofUrl: 'https://example.com/#proof=abc' });
+    expect(text).toContain('VibeGlossary Class Proof');
+    expect(text).toContain('250');
+    expect(text).toContain('Tinkerer');
+    expect(text).toContain('design-language');
+    expect(text).toContain('MET');
+    expect(text).toContain('https://example.com/#proof=abc');
+  });
+
+  it('shows NOT MET when class bar is not reached', () => {
+    const snap = { v: 1, s: 10, l: 'lurker', b: [], d: '2026-08-15T00:00:00.000Z' };
+    const text = buildProofText({ snapshot: snap });
+    expect(text).toContain('NOT MET');
+  });
+
+  it('handles missing snapshot gracefully', () => {
+    expect(buildProofText({})).toBe('');
+    expect(buildProofText()).toBe('');
+  });
+
+  it('contains no em dashes', () => {
+    const snap = { v: 1, s: 500, l: 'shipper', b: ['vibe-prompting', 'design-language'], d: '2026-08-15T00:00:00.000Z' };
+    const text = buildProofText({ snapshot: snap, proofUrl: 'https://example.com' });
+    expect(text).not.toContain('\u2014');
+    expect(text).not.toContain('\u2013');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes VibeGlossary usable as class work. Students can learn, earn a reasonable score, and submit proof to an instructor, all without accounts or a new backend.

## What changed

### 1. Class proof system (`src/lib/proof.js`, `ProofView.jsx`)

Students generate a **proof URL** or **proof text** they can paste into Canvas, a Google Form, or any LMS.

- **Class bar**: reach Tinkerer (200 pts) OR earn the "Vibe prompting for UI" path badge
- **Proof flow**: Score breakdown modal -> "Class proof" button -> copy link or text
- **Instructor view**: open the proof URL in a browser to see VibeScore, level, badges, date, and whether the class bar was met
- **No backend**: proof is a base64url-encoded JSON snapshot in the URL hash (`#proof=...`)
- **Hash routing**: `#proof=<encoded>` URLs auto-open the verify view when an instructor visits

### 2. "Vibe prompting for UI" class learning path

A cross-cluster path (first of its kind) pulling from Design Language, AI Literacy, and Web Foundations:
- 15 topics covering prompts/roles, design tokens, type, contrast, color, CTA hierarchy, brand constraints, component states, responsive design, LLMs, tokens, and tool calling
- 5-question end-of-path quiz (80% to earn the badge)
- Teal color theme

### 3. Design Language expansion (5 new topics)

Derived from practical prompting rules (MVPunk-style). All in the existing topic shape with mnemonic, summary, details, comparison, vibeTip, talkToAi (starter + example), and relatedGlossaryIds:

| Topic | What it teaches |
|---|---|
| `contrast-wcag` | WCAG AA/AAA contrast ratios; how to ask an AI for "WCAG AA contrast" instead of "make it readable" |
| `readable-type` | Base size >= 16px, line-height 1.4-1.6, never shrink body text |
| `design-contract` | Use existing tokens, do not invent inline values |
| `one-primary-cta` | One loud button per view; secondary/ghost/link for the rest |
| `brand-constraints` | "Brand is/is not" list that fits in a system prompt |

### 4. Updated design-language path quiz

Replaced 2 of 5 quiz questions to cover new topics (contrast-wcag, brand-constraints, one-primary-cta).

### 5. Tests (101 new, 1026 total)

- `proof.test.js`: classBar logic, snapshot round-trip, URL encoding, proof text format, em-dash absence
- `designLanguage.test.js`: all 19 topic shapes validated, new topic existence, quiz answer/option resolution, vibe-prompting cross-cluster path validation

### 6. Docs

- README: "For teachers" section with assignment instructions (class bar + proof link)
- CHANGELOG: v0.9.0 entry
- Version bump: 0.8.1 -> 0.9.0

## Constraints followed

- No em dashes in student-facing copy
- No new backend, no mail SDK, no student accounts
- Existing 925 tests still pass (same 2 Firebase-config test files that failed before still fail, unrelated)
- Existing social share preserved alongside new class-oriented "Copy proof" action
- Topic shape matches `src/data/designLanguage.js` exactly
- Quiz/path format matches `src/data/buildPaths.js` exactly

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1793534a-e6f5-4530-aaa6-0f353bd57db1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1793534a-e6f5-4530-aaa6-0f353bd57db1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

