### PR TITLE
Fix class proof modal and tour UX

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,7 +74,13 @@ export default function App() {
   );
   const { containerRef, onResizeStart: handleResizeStart } = usePanelResize(setPanelWidth);
   const [showTour, setShowTour] = useState(false);
+  const [tourForceMenu, setTourForceMenu] = useState(false);
   const { shouldOffer: shouldOfferTour, dismiss: dismissTourOffer } = useTourOffer();
+
+  const tourActions = useMemo(() => ({
+    openScoreBreakdown: (open) => setShowScoreBreakdown(open),
+    openMenu: (open) => setTourForceMenu(open),
+  }), []);
 
   // Keep isDesktop reactive so inline panel width is removed below lg breakpoint.
   useEffect(() => {
@@ -320,7 +326,8 @@ export default function App() {
 
       <FeatureTour
         isOpen={showTour}
-        onClose={() => setShowTour(false)}
+        onClose={() => { setShowTour(false); setTourForceMenu(false); }}
+        tourActions={tourActions}
       />
 
       <CheatSheet
@@ -432,6 +439,7 @@ export default function App() {
           onOpenBuildPaths={() => setShowBuildPaths(true)}
           onOpenScoreBreakdown={() => setShowScoreBreakdown(true)}
           onStartTour={() => setShowTour(true)}
+          tourForceMenu={tourForceMenu}
         />
       )}
 

--- a/src/components/FeatureTour.jsx
+++ b/src/components/FeatureTour.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useLayoutEffect } from 'react';
 import { X, ChevronRight, ChevronLeft } from 'lucide-react';
 import { TOUR_STEPS, TOUR_VERSION, hasSeenCurrentTour, markTourSeen } from '../data/tour';
 
@@ -35,12 +35,80 @@ function SpotlightOverlay({ rect }) {
   );
 }
 
-function TourCard({ step, currentIndex, total, onNext, onPrev, onClose }) {
+function TourArrow({ cardRef, targetRect }) {
+  const [arrow, setArrow] = useState(null);
+
+  useLayoutEffect(() => {
+    if (!cardRef.current || !targetRect) {
+      setArrow(null);
+      return;
+    }
+    const card = cardRef.current.getBoundingClientRect();
+    const targetCx = targetRect.left + targetRect.width / 2;
+    const targetCy = targetRect.top + targetRect.height / 2;
+    const cardCx = card.left + card.width / 2;
+    const cardCy = card.top + card.height / 2;
+
+    const gap = 8;
+    let direction, tipX, tipY;
+
+    if (card.top > targetRect.bottom) {
+      direction = 'up';
+      tipX = Math.max(card.left + 20, Math.min(card.right - 20, targetCx));
+      tipY = card.top - gap;
+    } else if (card.bottom < targetRect.top) {
+      direction = 'down';
+      tipX = Math.max(card.left + 20, Math.min(card.right - 20, targetCx));
+      tipY = card.bottom + gap;
+    } else if (card.left > targetRect.right) {
+      direction = 'left';
+      tipX = card.left - gap;
+      tipY = Math.max(card.top + 20, Math.min(card.bottom - 20, targetCy));
+    } else {
+      direction = 'right';
+      tipX = card.right + gap;
+      tipY = Math.max(card.top + 20, Math.min(card.bottom - 20, targetCy));
+    }
+
+    setArrow({ direction, tipX, tipY });
+  }, [targetRect]);
+
+  if (!arrow) return null;
+
+  const { direction, tipX, tipY } = arrow;
+  const size = 10;
+
+  let points;
+  switch (direction) {
+    case 'up':
+      points = `${tipX},${tipY} ${tipX - size},${tipY + size + 2} ${tipX + size},${tipY + size + 2}`;
+      break;
+    case 'down':
+      points = `${tipX},${tipY} ${tipX - size},${tipY - size - 2} ${tipX + size},${tipY - size - 2}`;
+      break;
+    case 'left':
+      points = `${tipX},${tipY} ${tipX + size + 2},${tipY - size} ${tipX + size + 2},${tipY + size}`;
+      break;
+    case 'right':
+      points = `${tipX},${tipY} ${tipX - size - 2},${tipY - size} ${tipX - size - 2},${tipY + size}`;
+      break;
+    default:
+      return null;
+  }
+
+  return (
+    <svg className="fixed inset-0 w-full h-full z-[9999] pointer-events-none" aria-hidden="true">
+      <polygon points={points} fill="#18181b" stroke="#3f3f46" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function TourCard({ step, currentIndex, total, onNext, onPrev, onClose, targetRect }) {
   const cardRef = useRef(null);
   const [position, setPosition] = useState({ top: '50%', left: '50%', transform: 'translate(-50%, -50%)' });
 
   useEffect(() => {
-    const rect = getTargetRect(step.target);
+    const rect = targetRect;
     if (!rect || !cardRef.current) {
       setPosition({ top: '50%', left: '50%', transform: 'translate(-50%, -50%)' });
       return;
@@ -49,7 +117,7 @@ function TourCard({ step, currentIndex, total, onNext, onPrev, onClose }) {
     const cardRect = cardRef.current.getBoundingClientRect();
     const viewW = window.innerWidth;
     const viewH = window.innerHeight;
-    const gap = 12;
+    const gap = 16;
 
     let top = rect.bottom + gap;
     let left = rect.left + rect.width / 2 - cardRect.width / 2;
@@ -63,66 +131,110 @@ function TourCard({ step, currentIndex, total, onNext, onPrev, onClose }) {
     if (left + cardRect.width > viewW - 16) left = viewW - 16 - cardRect.width;
 
     setPosition({ top: `${top}px`, left: `${left}px`, transform: 'none' });
-  }, [step]);
+  }, [step, targetRect]);
 
   return (
-    <div
-      ref={cardRef}
-      className="fixed z-[9999] w-80 max-w-[calc(100vw-2rem)] bg-zinc-900 border border-zinc-700 rounded-2xl shadow-2xl p-5 animate-fade-in"
-      style={position}
-      role="dialog"
-      aria-label={step.title}
-    >
-      <div className="flex items-start justify-between mb-2">
-        <h3 className="text-base font-bold text-white">{step.title}</h3>
-        <button
-          onClick={onClose}
-          className="p-1 rounded-lg text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors"
-          aria-label="Close tour"
-        >
-          <X size={16} />
-        </button>
-      </div>
-      <p className="text-sm text-zinc-300 leading-relaxed mb-4">{step.body}</p>
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-zinc-500 font-medium">
-          {currentIndex + 1} of {total}
-        </span>
-        <div className="flex items-center gap-2">
-          {currentIndex > 0 && (
-            <button
-              onClick={onPrev}
-              className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors"
-            >
-              <ChevronLeft size={14} />
-              Back
-            </button>
-          )}
+    <>
+      <TourArrow cardRef={cardRef} targetRect={targetRect} />
+      <div
+        ref={cardRef}
+        className="fixed z-[9999] w-80 max-w-[calc(100vw-2rem)] bg-zinc-900 border border-zinc-700 rounded-2xl shadow-2xl p-5 animate-fade-in"
+        style={position}
+        role="dialog"
+        aria-label={step.title}
+      >
+        <div className="flex items-start justify-between mb-2">
+          <h3 className="text-base font-bold text-white">{step.title}</h3>
           <button
-            onClick={onNext}
-            className="flex items-center gap-1 px-4 py-1.5 rounded-lg text-sm font-bold bg-violet-600 text-white hover:bg-violet-500 transition-colors"
+            onClick={onClose}
+            className="p-1 rounded-lg text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors"
+            aria-label="Close tour"
           >
-            {currentIndex < total - 1 ? (
-              <>Next <ChevronRight size={14} /></>
-            ) : 'Done'}
+            <X size={16} />
           </button>
         </div>
+        <p className="text-sm text-zinc-300 leading-relaxed mb-4">{step.body}</p>
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-zinc-500 font-medium">
+            {currentIndex + 1} of {total}
+          </span>
+          <div className="flex items-center gap-2">
+            {currentIndex > 0 && (
+              <button
+                onClick={onPrev}
+                className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors"
+              >
+                <ChevronLeft size={14} />
+                Back
+              </button>
+            )}
+            <button
+              onClick={onNext}
+              className="flex items-center gap-1 px-4 py-1.5 rounded-lg text-sm font-bold bg-violet-600 text-white hover:bg-violet-500 transition-colors"
+            >
+              {currentIndex < total - 1 ? (
+                <>Next <ChevronRight size={14} /></>
+              ) : 'Done'}
+            </button>
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 
-export default function FeatureTour({ isOpen, onClose }) {
+export default function FeatureTour({ isOpen, onClose, tourActions = {} }) {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [targetRect, setTargetRect] = useState(null);
+  const activeActionRef = useRef(null);
+
+  const runAction = useCallback((actionName) => {
+    if (activeActionRef.current === actionName) return;
+    const fn = tourActions[actionName];
+    if (fn) fn(true);
+    activeActionRef.current = actionName;
+  }, [tourActions]);
+
+  const clearAction = useCallback(() => {
+    if (!activeActionRef.current) return;
+    const fn = tourActions[activeActionRef.current];
+    if (fn) fn(false);
+    activeActionRef.current = null;
+  }, [tourActions]);
+
+  const refreshTarget = useCallback(() => {
+    const step = TOUR_STEPS[currentIndex];
+    if (!step) return;
+    const rect = getTargetRect(step.target);
+    setTargetRect(rect);
+  }, [currentIndex]);
 
   useEffect(() => {
-    if (isOpen) setCurrentIndex(0);
+    if (!isOpen) return;
+    setCurrentIndex(0);
+    activeActionRef.current = null;
   }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
+
+    const step = TOUR_STEPS[currentIndex];
+    if (!step) return;
+
+    if (step.action) {
+      runAction(step.action);
+      const timer = setTimeout(refreshTarget, 150);
+      return () => clearTimeout(timer);
+    } else {
+      clearAction();
+      refreshTarget();
+    }
+  }, [isOpen, currentIndex, runAction, clearAction, refreshTarget]);
+
+  useEffect(() => {
+    if (!isOpen) return;
     const handleKey = (e) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') handleClose();
       if (e.key === 'ArrowRight') handleNext();
       if (e.key === 'ArrowLeft') handlePrev();
     };
@@ -135,9 +247,10 @@ export default function FeatureTour({ isOpen, onClose }) {
       setCurrentIndex(i => i + 1);
     } else {
       markTourSeen();
+      clearAction();
       onClose();
     }
-  }, [currentIndex, onClose]);
+  }, [currentIndex, onClose, clearAction]);
 
   const handlePrev = useCallback(() => {
     if (currentIndex > 0) setCurrentIndex(i => i - 1);
@@ -145,13 +258,13 @@ export default function FeatureTour({ isOpen, onClose }) {
 
   const handleClose = useCallback(() => {
     markTourSeen();
+    clearAction();
     onClose();
-  }, [onClose]);
+  }, [onClose, clearAction]);
 
   if (!isOpen) return null;
 
   const step = TOUR_STEPS[currentIndex];
-  const targetRect = getTargetRect(step.target);
 
   return (
     <>
@@ -163,6 +276,7 @@ export default function FeatureTour({ isOpen, onClose }) {
         onNext={handleNext}
         onPrev={handlePrev}
         onClose={handleClose}
+        targetRect={targetRect}
       />
     </>
   );

--- a/src/components/layout/TopNav.jsx
+++ b/src/components/layout/TopNav.jsx
@@ -275,14 +275,16 @@ function MainMenu({
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${learnMode ? 'translate-x-6' : 'translate-x-1'}`} />
             </span>
           </button>
-          <MenuItem icon={<Trophy size={18} />} onClick={handlePaths}>
-            <span className="font-medium">Learning Paths</span>
-            {explore.badges.size > 0 && (
-              <span className="ml-auto flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 text-xs font-bold uppercase tracking-wider">
-                {explore.badges.size} <Check size={11} />
-              </span>
-            )}
-          </MenuItem>
+          <div data-tour="learning-paths">
+            <MenuItem icon={<Trophy size={18} />} onClick={handlePaths}>
+              <span className="font-medium">Learning Paths</span>
+              {explore.badges.size > 0 && (
+                <span className="ml-auto flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 text-xs font-bold uppercase tracking-wider">
+                  {explore.badges.size} <Check size={11} />
+                </span>
+              )}
+            </MenuItem>
+          </div>
           <MenuItem icon={<Shuffle size={18} />} onClick={handleSurprise}>
             Surprise Me
           </MenuItem>
@@ -513,10 +515,21 @@ export default function TopNav({
   onOpenBuildIndex, onOpenBuildPaths,
   onOpenScoreBreakdown,
   onStartTour,
+  tourForceMenu = false,
 }) {
   const [openDropdown, setOpenDropdown] = useState(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+
+  const prevTourForceMenu = useRef(false);
+  useEffect(() => {
+    if (tourForceMenu && !prevTourForceMenu.current) {
+      setOpenDropdown('menu');
+    } else if (!tourForceMenu && prevTourForceMenu.current && openDropdown === 'menu') {
+      setOpenDropdown(null);
+    }
+    prevTourForceMenu.current = tourForceMenu;
+  }, [tourForceMenu]);
 
   const activeCat = categories.find(c => c.items.some(i => i.id === activeItem));
   const activeItemData = activeCat?.items.find(i => i.id === activeItem);

--- a/src/components/learn/ProofView.jsx
+++ b/src/components/learn/ProofView.jsx
@@ -13,7 +13,6 @@ import {
   CLASS_PATH_ID,
 } from '../../lib/proof';
 import { copyToClipboard } from '../../lib/share';
-import ShareAchievement from './ShareAchievement';
 
 /**
  * Two modes:
@@ -255,17 +254,6 @@ export default function ProofView({
                   <><Copy size={16} /> Copy proof text for Canvas</>
                 )}
               </button>
-              <ShareAchievement
-                achievement={{
-                  kind: 'vibe-score',
-                  score: snapshot?.s ?? 0,
-                  level: lvl?.label || 'Lurker',
-                }}
-                variant="soft"
-                size="sm"
-                align="center"
-                label="Share on social"
-              />
             </div>
           )}
 

--- a/src/components/learn/ScoreBreakdownModal.jsx
+++ b/src/components/learn/ScoreBreakdownModal.jsx
@@ -58,6 +58,7 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onO
               <button
                 type="button"
                 onClick={onOpenProof}
+                data-tour="class-proof"
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold bg-indigo-500/10 hover:bg-indigo-500/20 text-indigo-600 dark:text-indigo-300 border border-indigo-500/20 transition-colors"
               >
                 <ShieldCheck size={14} />
@@ -65,16 +66,18 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onO
               </button>
             )}
             {total > 0 && (
-              <ShareAchievement
-                achievement={{
-                  kind: 'vibe-score',
-                  score: total,
-                  level: level.current.label,
-                }}
-                size="sm"
-                align="right"
-                label="Share score"
-              />
+              <span data-tour="share-score">
+                <ShareAchievement
+                  achievement={{
+                    kind: 'vibe-score',
+                    score: total,
+                    level: level.current.label,
+                  }}
+                  size="sm"
+                  align="right"
+                  label="Share score"
+                />
+              </span>
             )}
             <button
               onClick={onClose}

--- a/src/data/tour.js
+++ b/src/data/tour.js
@@ -1,4 +1,4 @@
-export const TOUR_VERSION = 1;
+export const TOUR_VERSION = 2;
 
 export const TOUR_STEPS = [
   {
@@ -22,14 +22,16 @@ export const TOUR_STEPS = [
   {
     id: 'share',
     title: 'Share your progress',
-    body: 'Hit a milestone? Open the score breakdown and share it on social. Bragging rights included.',
-    target: '[data-tour="vibe-score"]',
+    body: 'Hit a milestone? Open the score breakdown and use this button to share it on social. Bragging rights included.',
+    target: '[data-tour="share-score"]',
+    action: 'openScoreBreakdown',
   },
   {
     id: 'proof',
     title: 'Class proof',
-    body: 'Need to show an instructor you did the work? Generate a proof link from the score breakdown. No account needed.',
-    target: '[data-tour="vibe-score"]',
+    body: 'Need to show an instructor you did the work? Click this button to generate a proof link from the score breakdown. No account needed.',
+    target: '[data-tour="class-proof"]',
+    action: 'openScoreBreakdown',
   },
   {
     id: 'search',
@@ -41,7 +43,8 @@ export const TOUR_STEPS = [
     id: 'paths',
     title: 'Learning paths and badges',
     body: 'Open the menu to find curated paths that tie related topics together. Finish one and earn a badge.',
-    target: '[data-tour="main-menu"]',
+    target: '[data-tour="learning-paths"]',
+    action: 'openMenu',
   },
 ];
 

--- a/src/test/ProofView.test.jsx
+++ b/src/test/ProofView.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ProofView from '../components/learn/ProofView';
+
+vi.mock('../lib/proof', () => ({
+  classBar: () => ({ met: true, reasons: ['Reached Tinkerer'] }),
+  buildProofSnapshot: ({ score, level, badges }) => ({
+    s: score, l: level, b: [...(badges || [])], d: Date.now(),
+  }),
+  buildProofUrl: () => 'https://vibe-glossary.web.app/#proof=abc',
+  buildProofText: () => 'My proof text',
+  CLASS_BAR_POINTS: 200,
+  CLASS_PATH_ID: 'vibe-prompting-ui',
+}));
+
+vi.mock('../lib/share', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  score: { total: 250 },
+  level: 'tinkerer',
+  badges: new Set(['badge-1']),
+  proofSnapshot: null,
+};
+
+describe('ProofView', () => {
+  it('does not render Share on social or ShareAchievement', () => {
+    render(<ProofView {...defaultProps} />);
+    expect(screen.queryByText(/share on social/i)).toBeNull();
+    expect(screen.queryByText(/share what you learned/i)).toBeNull();
+    expect(screen.queryByLabelText(/share/i)).toBeNull();
+  });
+
+  it('renders Copy proof link button', () => {
+    render(<ProofView {...defaultProps} />);
+    expect(screen.getByText(/copy proof link/i)).toBeInTheDocument();
+  });
+
+  it('renders Copy proof text for Canvas button', () => {
+    render(<ProofView {...defaultProps} />);
+    expect(screen.getByText(/copy proof text for canvas/i)).toBeInTheDocument();
+  });
+
+  it('renders exactly one close button', () => {
+    render(<ProofView {...defaultProps} />);
+    const closeButtons = screen.getAllByLabelText(/close/i);
+    expect(closeButtons).toHaveLength(1);
+  });
+
+  it('does not render when isOpen is false', () => {
+    const { container } = render(<ProofView {...defaultProps} isOpen={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/test/tour.test.jsx
+++ b/src/test/tour.test.jsx
@@ -111,6 +111,52 @@ describe('Tour steps data', () => {
       expect(step.body).not.toContain('\u2014');
     }
   });
+
+  it('TOUR_VERSION is at least 2 (bumped for action-aware tour)', () => {
+    expect(TOUR_VERSION).toBeGreaterThanOrEqual(2);
+  });
+
+  it('steps that need an open panel declare an action', () => {
+    const stepsNeedingAction = TOUR_STEPS.filter(s =>
+      ['share', 'proof', 'paths'].includes(s.id)
+    );
+    expect(stepsNeedingAction.length).toBeGreaterThan(0);
+    for (const step of stepsNeedingAction) {
+      expect(step).toHaveProperty('action');
+      expect(typeof step.action).toBe('string');
+      expect(step.action.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('share step targets the share control, not the score pill', () => {
+    const shareStep = TOUR_STEPS.find(s => s.id === 'share');
+    expect(shareStep).toBeDefined();
+    expect(shareStep.target).not.toBe('[data-tour="vibe-score"]');
+    expect(shareStep.target).toMatch(/\[data-tour=/);
+  });
+
+  it('proof step targets the class proof button, not the score pill', () => {
+    const proofStep = TOUR_STEPS.find(s => s.id === 'proof');
+    expect(proofStep).toBeDefined();
+    expect(proofStep.target).not.toBe('[data-tour="vibe-score"]');
+    expect(proofStep.target).toMatch(/\[data-tour=/);
+  });
+
+  it('paths step targets the learning paths item, not the menu wrapper', () => {
+    const pathsStep = TOUR_STEPS.find(s => s.id === 'paths');
+    expect(pathsStep).toBeDefined();
+    expect(pathsStep.target).not.toBe('[data-tour="main-menu"]');
+    expect(pathsStep.target).toMatch(/\[data-tour=/);
+  });
+
+  it('action values are valid action names', () => {
+    const validActions = ['openScoreBreakdown', 'openMenu', 'focusSearch'];
+    for (const step of TOUR_STEPS) {
+      if (step.action) {
+        expect(validActions).toContain(step.action);
+      }
+    }
+  });
 });
 
 // ─── Tour persistence tests ─────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two live UX bugs:

1. **Class proof looks broken** - ProofView modal nests a `ShareAchievement` popover inside an `overflow-hidden` container, causing the share popover to be clipped, stacked on top of the proof card, with two close buttons and conflicting actions ("Share on social" vs "Copy proof text for Canvas").

2. **Tour is unclear** - Share, proof, and paths tour steps all point at `[data-tour="vibe-score"]` or `[data-tour="main-menu"]` without opening the actual UI, so newbies can't see the features being described. The tour card also has no arrow pointing to the highlighted target.

## Fix

### ProofView cleanup
- Removed `ShareAchievement` from `ProofView.jsx`. Social sharing already lives on `ScoreBreakdownModal`.
- Proof card is now one clean panel: class bar status, VibeScore, level, badges, date, and two copy buttons (Copy proof link, Copy proof text for Canvas). Single close button.

### Tour improvements
- Tour steps now declare an `action` field that opens the real UI before the spotlight lands:
  - **Share** step opens `ScoreBreakdownModal` and targets the actual Share score button (`[data-tour="share-score"]`)
  - **Proof** step opens `ScoreBreakdownModal` and targets the Class proof button (`[data-tour="class-proof"]`)
  - **Paths** step opens the hamburger menu and targets Learning Paths (`[data-tour="learning-paths"]`)
- `FeatureTour` executes actions on step entry and cleans them up on step exit
- Added SVG arrow/caret that points from the tour card to the highlighted target
- `TopNav` accepts `tourForceMenu` prop for external menu control during the tour
- Bumped `TOUR_VERSION` to 2 so returning users see the improved tour

### Data-tour attributes added
- `data-tour="share-score"` on ShareAchievement wrapper in ScoreBreakdownModal
- `data-tour="class-proof"` on Class proof button in ScoreBreakdownModal
- `data-tour="learning-paths"` on Learning Paths menu item in MainMenu

## Tests
- New `ProofView.test.jsx`: verifies no Share on social, no ShareAchievement, renders both copy buttons, exactly one close button
- Updated `tour.test.jsx`: verifies version >= 2, steps with panels declare actions, share/proof/paths target correct elements (not the old vibe-score/main-menu), action values are valid
- All 1056 existing tests pass. The 2 pre-existing Firebase config failures (`App.test.jsx`, `ExploreBar.test.jsx`) are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49647ef9-a5d9-4c0a-bd80-aa6a7f491fc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49647ef9-a5d9-4c0a-bd80-aa6a7f491fc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

