### PR TITLE
fix(firebase): guard getAnalytics against missing config

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,5 +13,13 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
-export const analytics = getAnalytics(app);
 export const db = getFirestore(app);
+
+// Analytics needs projectId + measurementId + a browser. Skip in tests, SSR,
+// or deploys with missing env vars — getAnalytics would throw synchronously.
+export const analytics =
+  typeof window !== 'undefined' &&
+  firebaseConfig.projectId &&
+  firebaseConfig.measurementId
+    ? getAnalytics(app)
+    : null;


### PR DESCRIPTION
## Summary

Fixing a synchronous crash at module load in `src/firebase.js` that was hiding a chunk of the test suite and would also break any dev/preview run without a `.env`.

**Root cause:** `firebase.js` called `getAnalytics(app)` unconditionally at module load. Firebase Analytics throws synchronously when `projectId` is missing, and every consumer (`useCategories`, `useGlossary`, `main.jsx`, any component that touches those hooks) pulls this module in.

**Impact:**
- `src/test/App.test.jsx` and `src/test/ExploreBar.test.jsx` both reported `0 test` and failed with `FirebaseError: Missing App configuration value: "projectId"` — 27 tests were being silently skipped.
- Any dev / preview run without a `.env` (which is gitignored, no fallback in the repo) would crash the same way.

**Fix:** Only initialize Analytics when `projectId` + `measurementId` are set and we are in a browser. Firestore init stays as it was, and both hooks already fall back to local data on any Firestore error, so no other consumer needs to change.

## Test plan

- [x] `npm test` — 14/14 files, **1083/1083 tests** (was 12/14 files, 1056 tests before the fix)
- [x] `npm run build` — builds cleanly
- [x] Ran `npm run lint` — 0 errors (warnings unchanged, all pre-existing unused-import noise)
- [ ] Verify locally that a real deploy with valid `VITE_FIREBASE_*` env vars still initializes Analytics (I only had access to the empty-config path in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SA3BgKi9o19cw9YDjWvaWq)_