### PR TITLE
fix: Tess live bugs 13-19 (shareable URLs and chrome)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,9 +35,12 @@ import {
 } from './data/buildLiteracy';
 import { DEMO_REGISTRY } from './data/demoRegistry';
 import { decodeProof } from './lib/proof';
+import { topicFromWindow, syncTopicUrl } from './lib/topicUrl';
+import HoverTip from './components/ui/HoverTip';
 
 export default function App() {
   const [showWelcome, setShowWelcome] = useState(() => {
+    if (topicFromWindow()) return false;
     return !localStorage.getItem('vg-visited');
   });
   const [showCheatSheet, setShowCheatSheet] = useState(false);
@@ -51,9 +54,15 @@ export default function App() {
   const [showScoreBreakdown, setShowScoreBreakdown] = useState(false);
   const [showProof, setShowProof] = useState(false);
   const [proofSnapshot, setProofSnapshot] = useState(null);
-  const [activeItem, setActiveItem]       = useState('modal');
-  const [activeBuildTopic, setActiveBuildTopic] = useState(() => BUILD_TOPIC_IDS[0] || 'mvp');
-  const [siteSection, setSiteSection]     = useState('glossary'); // 'glossary' | 'build'
+  const [activeItem, setActiveItem]       = useState(() => {
+    const boot = topicFromWindow();
+    return boot?.section === 'glossary' ? boot.id : 'modal';
+  });
+  const [activeBuildTopic, setActiveBuildTopic] = useState(() => {
+    const boot = topicFromWindow();
+    return boot?.section === 'build' ? boot.id : (BUILD_TOPIC_IDS[0] || 'mvp');
+  });
+  const [siteSection, setSiteSection]     = useState(() => topicFromWindow()?.section || 'glossary');
   const [infoOpen, setInfoOpen]           = useState(true);
   const [mobileView, setMobileView]       = useState('info'); // 'info' or 'preview'
   const [darkMode, setDarkMode]           = useState(true);
@@ -129,6 +138,37 @@ export default function App() {
     checkHash();
     window.addEventListener('hashchange', checkHash);
     return () => window.removeEventListener('hashchange', checkHash);
+  }, []);
+
+  // Shareable topic URLs. A teaching topic has an address that reloads to
+  // the same topic (CLAUDE.md: a glossary you cannot link is not teachable).
+  const urlReady = useRef(false);
+  useEffect(() => {
+    if (showWelcome) return;
+    const id = siteSection === 'build' ? activeBuildTopic : activeItem;
+    syncTopicUrl(siteSection, id, { replace: !urlReady.current });
+    urlReady.current = true;
+  }, [showWelcome, siteSection, activeItem, activeBuildTopic]);
+
+  useEffect(() => {
+    function applyLocation() {
+      const next = topicFromWindow();
+      if (!next) return;
+      if (next.section === 'build') {
+        setSiteSection('build');
+        setActiveBuildTopic(next.id);
+      } else {
+        setSiteSection('glossary');
+        setActiveItem(next.id);
+      }
+      setShowWelcome(false);
+    }
+    window.addEventListener('popstate', applyLocation);
+    window.addEventListener('hashchange', applyLocation);
+    return () => {
+      window.removeEventListener('popstate', applyLocation);
+      window.removeEventListener('hashchange', applyLocation);
+    };
   }, []);
 
   // Reset options when switching components & track visit
@@ -292,10 +332,12 @@ export default function App() {
       {prevItem && (
         <button
           onClick={() => setActiveItem(prevItem)}
-          className="group relative w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center"
+          className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] bg-transparent"
           aria-label={`Previous: ${prevData?.title}`}
         >
-          <ChevronLeft size={16} className="text-zinc-600 dark:text-zinc-300" />
+          <span className="w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center">
+            <ChevronLeft size={16} className="text-zinc-600 dark:text-zinc-300" />
+          </span>
           <span className="pointer-events-none absolute right-full top-1/2 -translate-y-1/2 mr-2 whitespace-nowrap px-4 py-2.5 rounded-lg bg-zinc-900 dark:bg-zinc-700 text-right opacity-0 group-hover:opacity-100 transition-opacity shadow-xl z-30">
             <span className="block text-xs uppercase tracking-wider text-zinc-400 font-bold">Previous</span>
             <span className="block text-lg font-semibold text-white">{prevData?.title}</span>
@@ -305,10 +347,12 @@ export default function App() {
       {nextItem && (
         <button
           onClick={() => setActiveItem(nextItem)}
-          className="group relative w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center"
+          className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] bg-transparent"
           aria-label={`Next: ${nextData?.title}`}
         >
-          <ChevronRight size={16} className="text-zinc-600 dark:text-zinc-300" />
+          <span className="w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center">
+            <ChevronRight size={16} className="text-zinc-600 dark:text-zinc-300" />
+          </span>
           <span className="pointer-events-none absolute right-0 top-full mt-2 whitespace-nowrap px-4 py-2.5 rounded-lg bg-zinc-900 dark:bg-zinc-700 text-right opacity-0 group-hover:opacity-100 transition-opacity shadow-xl z-30">
             <span className="block text-xs uppercase tracking-wider text-zinc-400 font-bold">Next</span>
             <span className="block text-lg font-semibold text-white">{nextData?.title}</span>
@@ -531,8 +575,8 @@ export default function App() {
                       <button
                         onClick={toggleLearnMode}
                         aria-pressed={learnMode}
-                        title={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each component)'}
-                        className={`ml-1 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
+                        aria-label={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each component)'}
+                        className={`group relative ml-1 inline-flex items-center gap-1.5 px-2.5 py-1 before:absolute before:inset-y-[-8px] before:inset-x-[-4px] before:content-[''] rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
                           learnMode
                             ? 'bg-indigo-600 border-indigo-600 text-white hover:bg-indigo-500'
                             : 'bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'
@@ -540,6 +584,7 @@ export default function App() {
                       >
                         <GraduationCap size={13} />
                         {learnMode ? 'Learn Mode: On' : 'Quiz me'}
+                        <HoverTip text={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each component)'} />
                       </button>
                       <TopicTierBadge tier={explore.tiers?.[activeItem]} className="ml-1" />
                     </div>
@@ -551,10 +596,11 @@ export default function App() {
                     {carouselArrows}
                     <button
                       onClick={() => setInfoOpen(false)}
-                      className="hidden lg:block p-1.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
-                      title="Close panel"
+                      className="group relative hidden lg:flex items-center justify-center min-w-[44px] min-h-[44px] p-1.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+                      aria-label="Close panel"
                     >
                       <PanelLeftClose size={18} />
+                      <HoverTip text="Close panel" align="right" />
                     </button>
                   </div>
                 </div>
@@ -603,7 +649,7 @@ export default function App() {
                       <button
                         key={sib.id}
                         onClick={() => setCompareWith(sib.id)}
-                        className={`px-3 py-1 rounded-full text-sm lg:text-base font-medium border border-zinc-200 dark:border-zinc-700 ${activeCat.text} hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-colors`}
+                        className={`relative px-3 py-1 min-h-[44px] rounded-full text-sm lg:text-base font-medium border border-zinc-200 dark:border-zinc-700 ${activeCat.text} hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-colors`}
                       >
                         vs {sib.name}
                       </button>
@@ -639,10 +685,11 @@ export default function App() {
               {!infoOpen && (
                 <button
                   onClick={() => setInfoOpen(true)}
-                  className="p-2.5 bg-white/80 dark:bg-zinc-900/80 backdrop-blur border border-zinc-200 dark:border-zinc-800 rounded-lg shadow-sm hover:bg-white dark:hover:bg-zinc-800 text-zinc-500 dark:text-zinc-400 transition-colors"
-                  title="Open Definition"
+                  className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] p-2.5 bg-white/80 dark:bg-zinc-900/80 backdrop-blur border border-zinc-200 dark:border-zinc-800 rounded-lg shadow-sm hover:bg-white dark:hover:bg-zinc-800 text-zinc-500 dark:text-zinc-400 transition-colors"
+                  aria-label="Open Definition"
                 >
                   <BookOpen size={18} />
+                  <HoverTip text="Open Definition" />
                 </button>
               )}
             </div>

--- a/src/components/layout/TopNav.jsx
+++ b/src/components/layout/TopNav.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, cloneElement } from 'react';
+import HoverTip from '../ui/HoverTip';
 import {
   Sun, Moon, Search, ChevronDown, ChevronRight, X, Home,
   Menu as MenuIcon, Shuffle, Trophy, GraduationCap,
@@ -40,15 +41,20 @@ function Popover({ children, isOpen, onClose, align = 'left', width = 260 }) {
     const handleClick = (e) => {
       if (ref.current && !ref.current.contains(e.target)) onClose();
     };
+    const handleKey = (e) => { if (e.key === 'Escape') onClose(); };
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
   return (
     <div
       ref={ref}
-      className={`absolute top-full mt-2 ${align === 'right' ? 'right-0' : 'left-0'} bg-white dark:bg-zinc-900 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 py-1.5 animate-fade-in max-h-[75vh] overflow-y-auto`}
+      className={`absolute top-full mt-2 ${align === 'right' ? 'right-0' : 'left-0'} bg-white dark:bg-zinc-800 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 py-1.5 animate-fade-in max-h-[75vh] overflow-y-auto`}
       style={{ minWidth: width }}
     >
       {children}
@@ -71,7 +77,7 @@ function NavPillTooltip({ text, align = 'left', hideFrom, hidden }) {
   return (
     <span
       role="tooltip"
-      className={`pointer-events-none absolute top-full mt-1.5 z-[60] ${alignClass} whitespace-nowrap max-w-[min(20rem,calc(100vw-2rem))] truncate px-3 py-2 rounded-lg text-sm font-semibold text-zinc-700 dark:text-zinc-200 bg-white dark:bg-zinc-900 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 shadow-2xl opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${hideClass}`}
+      className={`pointer-events-none absolute top-full mt-1.5 z-[60] ${alignClass} whitespace-nowrap max-w-[min(20rem,calc(100vw-2rem))] truncate px-3 py-2 rounded-lg text-sm font-semibold text-zinc-700 dark:text-zinc-200 bg-white dark:bg-zinc-800 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 shadow-2xl opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${hideClass}`}
     >
       {text}
     </span>
@@ -89,7 +95,7 @@ function PillDropdown({
   // Tailwind max-width class applied to the label span. Caps long labels (like
   // 60-character build literacy topic titles) so they truncate with an
   // ellipsis instead of pushing other pills off the bar.
-  labelMaxClass = 'max-w-[12rem] xl:max-w-[18rem]',
+  labelMaxClass = 'max-w-[7rem] lg:max-w-[10rem] xl:max-w-[12rem]',
 }) {
   const wrapRef = useRef(null);
   const labelBp = iconOnly ? null : (LABEL_FROM[labelFrom] || LABEL_FROM.xl);
@@ -101,12 +107,17 @@ function PillDropdown({
     const handleClick = (e) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target)) onClose();
     };
+    const handleKey = (e) => { if (e.key === 'Escape') onClose(); };
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
   }, [isOpen, onClose]);
 
   return (
-    <div ref={wrapRef} className={`relative ${iconOnly ? '' : 'flex-1 md:flex-none min-w-0'}`}>
+    <div ref={wrapRef} className={`relative min-w-0 ${iconOnly ? '' : 'max-w-full'}`}>
       <button
         onClick={onToggle}
         aria-label={ariaLabel || label}
@@ -137,7 +148,7 @@ function PillDropdown({
       </button>
       {isOpen && (
         <div
-          className={`absolute top-full mt-2 ${align === 'right' ? 'right-0' : 'left-0'} bg-white dark:bg-zinc-900 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 py-1.5 animate-fade-in max-h-[75vh] overflow-y-auto`}
+          className={`absolute top-full mt-2 ${align === 'right' ? 'right-0' : 'left-0'} bg-white dark:bg-zinc-800 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 py-1.5 animate-fade-in max-h-[75vh] overflow-y-auto`}
           style={{ minWidth: width || 280 }}
         >
           {children}
@@ -410,7 +421,7 @@ function MainMenu({
       <div className="border-t border-zinc-100 dark:border-zinc-800">
         <SectionHeader icon={<Settings size={14} />} label="Settings" />
         <button
-          onClick={() => setDarkMode(!darkMode)}
+          onClick={() => { setDarkMode(!darkMode); onClose(); }}
           className="w-full flex items-center gap-3 px-4 py-2.5 text-base hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-colors"
         >
           {darkMode ? <Moon size={18} /> : <Sun size={18} />}
@@ -471,10 +482,10 @@ function SearchResultsList({ results, onSelect, maxHeight = 'max-h-80' }) {
 
   const renderHeader = (label, count) => (
     <div className="px-4 pt-2 pb-1 flex items-center justify-between">
-      <span className="text-[11px] font-bold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
+      <span className="text-xs font-bold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
         {label}
       </span>
-      <span className="text-[11px] text-zinc-400 dark:text-zinc-500">{count}</span>
+      <span className="text-xs text-zinc-400 dark:text-zinc-500">{count}</span>
     </div>
   );
 
@@ -668,6 +679,7 @@ export default function TopNav({
         setTimeout(() => searchInputRef.current?.focus(), 50);
       }
       if (e.key === 'Escape') {
+        setOpenDropdown(null);
         setSearchOpen(false);
         setSearchTerm('');
       }
@@ -682,23 +694,22 @@ export default function TopNav({
         <div className={`absolute inset-0 bg-gradient-to-r ${catColors.gradient} opacity-[0.10] dark:opacity-[0.18] transition-opacity duration-500`} />
       </div>
       <div className="relative flex items-center justify-between gap-2 px-3 sm:px-4 md:px-6 h-20">
-        {/* Left: Logo + pill dropdowns */}
-        <div className="flex items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0">
+        {/* Left: Logo + pills. Overflow so long titles cannot cover chrome. */}
+        <div className="flex items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0 flex-1 overflow-hidden pr-2">
           <button
             onClick={onGetStarted}
-            className="flex items-center gap-2 lg:gap-3 font-bold tracking-tight text-zinc-900 dark:text-white shrink-0"
-            title="Welcome screen"
-            aria-label="VibeGlossary — welcome screen"
+            className="group relative flex items-center gap-2 lg:gap-3 font-bold tracking-tight text-zinc-900 dark:text-white shrink-0"
+            aria-label="VibeGlossary, welcome screen"
           >
             <img src="/logo.png" alt="" className="w-11 h-11 sm:w-12 sm:h-12 lg:w-14 lg:h-14 rounded-xl object-cover" />
             <span className="hidden lg:inline text-xl lg:text-2xl">VibeGlossary</span>
+            <HoverTip text="Welcome screen" />
           </button>
 
           <div className="flex shrink-0 items-center rounded-xl bg-zinc-100 dark:bg-zinc-900 p-0.5 sm:p-1 border border-zinc-200 dark:border-zinc-800">
             <button
               type="button"
               onClick={() => setSiteSection('glossary')}
-              title="UI Glossary"
               aria-label="UI Glossary"
               aria-current={siteSection === 'glossary' ? 'page' : undefined}
               className={`flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] lg:min-w-0 px-2.5 lg:px-3 py-2 rounded-lg text-xs lg:text-sm font-semibold transition-colors ${
@@ -713,7 +724,6 @@ export default function TopNav({
             <button
               type="button"
               onClick={() => setSiteSection('build')}
-              title="Build literacy"
               aria-label="Build literacy"
               aria-current={siteSection === 'build' ? 'page' : undefined}
               className={`flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] lg:min-w-0 px-2.5 lg:px-3 py-2 rounded-lg text-xs lg:text-sm font-semibold transition-colors ${
@@ -733,7 +743,7 @@ export default function TopNav({
 
           {/* Category */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block">
+          <div className="hidden md:block min-w-0">
             <PillDropdown
               icon={
                 <span className={`flex items-center gap-1.5 ${catColors.accent}`}>
@@ -775,7 +785,7 @@ export default function TopNav({
 
           {/* Component */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block">
+          <div className="hidden md:block min-w-0">
             <PillDropdown
               icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
               label={activeItemData?.name || 'Modal'}
@@ -811,7 +821,7 @@ export default function TopNav({
 
           {/* Build literacy: Cluster pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block">
+            <div className="hidden md:block min-w-0">
               <PillDropdown
                 icon={
                   <span className={`flex items-center gap-1.5 ${activeBuildColors.accent}`}>
@@ -855,7 +865,7 @@ export default function TopNav({
 
           {/* Build literacy: Topic pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block">
+            <div className="hidden md:block min-w-0">
               <PillDropdown
                 icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
                 label={activeBuildTopicData?.title || 'Pick a topic'}
@@ -891,7 +901,7 @@ export default function TopNav({
         </div>
 
         {/* Right: Search + Menu */}
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex items-center gap-2 shrink-0 relative z-20">
           {/* Learning + Help icon-only pills, only at 2xl+ where there's room.
               Below that they live inside the hamburger menu instead. */}
           <div className="hidden 2xl:flex items-center">
@@ -1030,19 +1040,19 @@ export default function TopNav({
             <button
               onClick={() => { setSearchOpen(true); setTimeout(() => searchInputRef.current?.focus(), 50); }}
               data-tour="search"
-              className="hidden md:flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
+              className="group relative hidden md:flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] px-2.5 py-2 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
               aria-label="Search (⌘K)"
-              title="Search (⌘K)"
             >
               <Search size={20} />
-              <kbd className="hidden xl:flex items-center text-[11px] font-mono bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 px-1.5 py-0.5 rounded text-zinc-400 leading-none">⌘K</kbd>
+              <kbd className="hidden xl:flex items-center text-xs font-mono bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 px-1.5 py-0.5 rounded text-zinc-400 leading-none">⌘K</kbd>
+              <HoverTip text="Search" align="right" />
             </button>
           )}
 
           {/* Mobile: icon-only search toggle */}
           <button
             onClick={() => { setSearchOpen(!searchOpen); setTimeout(() => searchInputRef.current?.focus(), 50); }}
-            className="md:hidden p-2.5 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
+            className="group relative md:hidden flex items-center justify-center min-w-[44px] min-h-[44px] p-2.5 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
             aria-label="Search"
           >
             <Search size={20} />
@@ -1070,7 +1080,7 @@ export default function TopNav({
           )}
 
           {/* Your Progress pill between search and hamburger */}
-          <div className="hidden md:block">
+          <div className="hidden md:block min-w-0">
             <PillDropdown
               icon={
                 <div className="relative w-7 h-7 shrink-0">
@@ -1159,7 +1169,7 @@ export default function TopNav({
           <div className="relative" data-tour="main-menu">
             <button
               onClick={() => setOpenDropdown(openDropdown === 'menu' ? null : 'menu')}
-              className={`flex items-center gap-1.5 pl-2.5 pr-2 py-1.5 rounded-full border transition-colors ${
+              className={`group relative flex items-center justify-center min-w-[44px] min-h-[44px] gap-1.5 pl-2.5 pr-2 py-1.5 rounded-full border transition-colors ${
                 openDropdown === 'menu'
                   ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-300 dark:border-zinc-600'
                   : 'bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
@@ -1167,6 +1177,7 @@ export default function TopNav({
               aria-label="Open menu"
             >
               <MenuIcon size={16} className="text-zinc-600 dark:text-zinc-300" />
+              <HoverTip text="Menu" align="right" hidden={openDropdown === 'menu'} />
               <div className="md:hidden relative w-7 h-7 shrink-0">
                 <svg className="w-7 h-7 -rotate-90" viewBox="0 0 36 36">
                   <circle cx="18" cy="18" r="15" fill="none" stroke="currentColor" className="text-zinc-200 dark:text-zinc-700" strokeWidth="4" />

--- a/src/components/layout/UserMenu.jsx
+++ b/src/components/layout/UserMenu.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import HoverTip from '../ui/HoverTip';
 import {
   UserRound, LogOut, Trophy, FileCheck2, RotateCcw, Loader2, CloudUpload, CloudOff, Check,
 } from 'lucide-react';
@@ -10,7 +11,7 @@ const SYNC_LINES = {
   restoring: { icon: Loader2, spin: true, text: 'Restoring your backup…', tone: 'text-zinc-500 dark:text-zinc-400' },
   saving: { icon: CloudUpload, text: 'Backing up…', tone: 'text-zinc-500 dark:text-zinc-400' },
   saved: { icon: Check, text: 'Progress backed up', tone: 'text-emerald-600 dark:text-emerald-400' },
-  error: { icon: CloudOff, text: 'Backup failed — retries on your next change', tone: 'text-amber-600 dark:text-amber-400' },
+  error: { icon: CloudOff, text: 'Backup failed. Retries on your next change', tone: 'text-amber-600 dark:text-amber-400' },
   idle: { icon: CloudUpload, text: 'Backup on', tone: 'text-zinc-500 dark:text-zinc-400' },
 };
 
@@ -83,8 +84,15 @@ export default function UserMenu({
     const handleClick = (e) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target)) onClose();
     };
+    const handleKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
   }, [isOpen, onClose]);
 
   const handleEmailSubmit = async (e) => {
@@ -116,9 +124,8 @@ export default function UserMenu({
     <div ref={wrapRef} className="relative" data-tour="user-menu">
       <button
         onClick={() => { clearError?.(); onToggle(); }}
-        aria-label={user ? `Account: ${user.displayName || user.email}` : 'Sign in'}
-        title={user ? 'Account' : 'Sign in — back up your progress (optional)'}
-        className={`flex items-center justify-center w-10 h-10 rounded-full border transition-colors ${
+        aria-label={user ? `Account: ${user.displayName || user.email}` : 'Sign in. Back up your progress (optional)'}
+        className={`group relative flex items-center justify-center min-w-[44px] min-h-[44px] w-10 h-10 rounded-full border transition-colors ${
           isOpen
             ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-300 dark:border-zinc-600'
             : 'bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
@@ -127,11 +134,16 @@ export default function UserMenu({
         {user
           ? <Avatar user={user} />
           : <UserRound size={20} className="text-zinc-600 dark:text-zinc-300" />}
+        <HoverTip
+          text={user ? 'Account' : 'Sign in. Back up your progress (optional)'}
+          align="right"
+          hidden={isOpen}
+        />
       </button>
 
       {isOpen && (
         <div
-          className="absolute top-full mt-2 right-0 bg-white dark:bg-zinc-900 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 py-1.5 animate-fade-in max-h-[75vh] overflow-y-auto"
+          className="absolute top-full mt-2 right-0 bg-white dark:bg-zinc-800 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 py-1.5 animate-fade-in max-h-[75vh] overflow-y-auto opacity-100"
           style={{ width: 'min(340px, calc(100vw - 16px))' }}
         >
           {user ? (
@@ -175,7 +187,7 @@ export default function UserMenu({
                   Back up your progress
                 </p>
                 <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 leading-snug">
-                  Totally optional — everything saves on this device either way.
+                  Totally optional. Everything saves on this device either way.
                   Sign in to keep your score and badges safe and use them on any device.
                 </p>
               </div>

--- a/src/components/layout/WhatsNewMenu.jsx
+++ b/src/components/layout/WhatsNewMenu.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkles, ChevronRight } from 'lucide-react';
+import HoverTip from '../ui/HoverTip';
 import {
   WHATS_NEW, APP_VERSION, hasUnseenReleases, markReleasesSeen,
 } from '../../data/releases';
@@ -33,7 +34,7 @@ function ReleaseList({ onAction, dense = false }) {
             }`}
           >
             <div className="flex items-center gap-2">
-              <span className={`px-2 py-0.5 rounded-full text-[11px] font-bold uppercase tracking-wider ${TAG_STYLES[entry.tag] || TAG_STYLES.improvement}`}>
+              <span className={`px-2 py-0.5 rounded-full text-xs font-bold uppercase tracking-wider ${TAG_STYLES[entry.tag] || TAG_STYLES.improvement}`}>
                 {TAG_LABELS[entry.tag] || entry.tag}
               </span>
               <span className="ml-auto text-xs text-zinc-400 dark:text-zinc-500 tabular-nums">v{entry.version}</span>
@@ -114,8 +115,15 @@ export default function WhatsNewMenu({ isOpen, onToggle, onClose, onAction }) {
     const handleClick = (e) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target)) onClose();
     };
+    const handleKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
   }, [isOpen, onClose]);
 
   return (
@@ -123,14 +131,14 @@ export default function WhatsNewMenu({ isOpen, onToggle, onClose, onAction }) {
       <button
         onClick={onToggle}
         aria-label="What's new"
-        title="What's new"
-        className={`relative flex items-center px-3 py-2.5 rounded-lg transition-colors ${
+        className={`group relative flex items-center justify-center min-w-[44px] min-h-[44px] px-3 py-2.5 rounded-lg transition-colors ${
           isOpen
             ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-white'
             : 'text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800/70'
         }`}
       >
         <Sparkles size={22} />
+        <HoverTip text="What's new" align="right" hidden={isOpen} />
         {unseen && (
           <span
             className="absolute top-1.5 right-1.5 w-2.5 h-2.5 rounded-full bg-indigo-500 ring-2 ring-white dark:ring-zinc-950"
@@ -141,7 +149,7 @@ export default function WhatsNewMenu({ isOpen, onToggle, onClose, onAction }) {
 
       {isOpen && (
         <div
-          className="absolute top-full mt-2 right-0 bg-white dark:bg-zinc-900 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 animate-fade-in max-h-[75vh] overflow-y-auto"
+          className="absolute top-full mt-2 right-0 bg-white dark:bg-zinc-800 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 rounded-xl shadow-2xl z-50 animate-fade-in max-h-[75vh] overflow-y-auto opacity-100"
           style={{ width: 'min(380px, calc(100vw - 16px))' }}
         >
           <div className="flex items-center gap-2 px-4 pt-3 pb-2 border-b border-zinc-100 dark:border-zinc-800">

--- a/src/components/learn/BuildLiteracyView.jsx
+++ b/src/components/learn/BuildLiteracyView.jsx
@@ -11,6 +11,7 @@ import { useGlossary } from '../../hooks/useGlossary';
 import usePanelResize from '../../hooks/usePanelResize';
 import BuildTopicView from './BuildTopicView';
 import TalkToAiCard from './TalkToAiCard';
+import HoverTip from '../ui/HoverTip';
 
 /**
  * Build Literacy section: two-pane body that mirrors the UI Glossary.
@@ -166,10 +167,11 @@ export default function BuildLiteracyView({
             <div className="hidden lg:flex absolute top-4 left-4 z-30 gap-2">
               <button
                 onClick={() => setInfoOpen(true)}
-                className="p-2.5 bg-white/80 dark:bg-zinc-900/80 backdrop-blur border border-zinc-200 dark:border-zinc-800 rounded-lg shadow-sm hover:bg-white dark:hover:bg-zinc-800 text-zinc-500 dark:text-zinc-400 transition-colors"
-                title="Open Definition"
+                className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] p-2.5 bg-white/80 dark:bg-zinc-900/80 backdrop-blur border border-zinc-200 dark:border-zinc-800 rounded-lg shadow-sm hover:bg-white dark:hover:bg-zinc-800 text-zinc-500 dark:text-zinc-400 transition-colors"
+                aria-label="Open Definition"
               >
                 <BookOpen size={18} />
+                <HoverTip text="Open Definition" />
               </button>
             </div>
           )}

--- a/src/components/learn/BuildTopicView.jsx
+++ b/src/components/learn/BuildTopicView.jsx
@@ -5,6 +5,7 @@ import {
 import DefinitionPanel from '../ui/DefinitionPanel';
 import QuizCard from './QuizCard';
 import TopicTierBadge from './TopicTierBadge';
+import HoverTip from '../ui/HoverTip';
 import { getBuildClusterColors } from '../../data/buildLiteracy';
 import { tierFor } from '../../lib/scoring';
 
@@ -50,10 +51,12 @@ export default function BuildTopicView({
       {prevTopic && (
         <button
           onClick={() => onSelectTopic(prevTopic.id)}
-          className="group relative w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center"
+          className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] bg-transparent"
           aria-label={`Previous topic: ${prevTopic.title}`}
         >
-          <ChevronLeft size={16} className="text-zinc-600 dark:text-zinc-300" />
+          <span className="w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center">
+            <ChevronLeft size={16} className="text-zinc-600 dark:text-zinc-300" />
+          </span>
           <span className="pointer-events-none absolute right-full top-1/2 -translate-y-1/2 mr-2 whitespace-nowrap px-4 py-2.5 rounded-lg bg-zinc-900 dark:bg-zinc-700 text-right opacity-0 group-hover:opacity-100 transition-opacity shadow-xl z-30">
             <span className="block text-xs uppercase tracking-wider text-zinc-400 font-bold">Previous</span>
             <span className="block text-lg font-semibold text-white">{prevTopic.title}</span>
@@ -63,10 +66,12 @@ export default function BuildTopicView({
       {nextTopic && (
         <button
           onClick={() => onSelectTopic(nextTopic.id)}
-          className="group relative w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center"
+          className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] bg-transparent"
           aria-label={`Next topic: ${nextTopic.title}`}
         >
-          <ChevronRight size={16} className="text-zinc-600 dark:text-zinc-300" />
+          <span className="w-8 h-8 rounded-full bg-white/80 dark:bg-zinc-900/80 hover:bg-white dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 transition-colors flex items-center justify-center">
+            <ChevronRight size={16} className="text-zinc-600 dark:text-zinc-300" />
+          </span>
           <span className="pointer-events-none absolute right-0 top-full mt-2 whitespace-nowrap px-4 py-2.5 rounded-lg bg-zinc-900 dark:bg-zinc-700 text-right opacity-0 group-hover:opacity-100 transition-opacity shadow-xl z-30">
             <span className="block text-xs uppercase tracking-wider text-zinc-400 font-bold">Next</span>
             <span className="block text-lg font-semibold text-white">{nextTopic.title}</span>
@@ -94,8 +99,8 @@ export default function BuildTopicView({
               type="button"
               onClick={toggleLearnMode}
               aria-pressed={learnMode}
-              title={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each topic)'}
-              className={`ml-1 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
+              aria-label={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each topic)'}
+              className={`group relative ml-1 inline-flex items-center gap-1.5 px-2.5 py-1 before:absolute before:inset-y-[-8px] before:inset-x-[-4px] before:content-[''] rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
                 learnMode
                   ? 'bg-indigo-600 border-indigo-600 text-white hover:bg-indigo-500'
                   : 'bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'
@@ -103,6 +108,7 @@ export default function BuildTopicView({
             >
               <GraduationCap size={13} />
               {learnMode ? 'Learn Mode: On' : 'Quiz me'}
+              <HoverTip text={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each topic)'} />
             </button>
             <TopicTierBadge
               tier={topicTier || tierFor({ visited: true, attempts: pastAttempts })}
@@ -119,11 +125,11 @@ export default function BuildTopicView({
             <button
               type="button"
               onClick={onCloseInfo}
-              className="hidden lg:block p-1.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
-              title="Close panel"
+              className="group relative hidden lg:flex items-center justify-center min-w-[44px] min-h-[44px] p-1.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
               aria-label="Close definition panel"
             >
               <PanelLeftClose size={18} />
+              <HoverTip text="Close panel" align="right" />
             </button>
           )}
         </div>
@@ -197,8 +203,7 @@ export default function BuildTopicView({
                 key={sib.id}
                 type="button"
                 onClick={() => onSelectTopic(sib.id)}
-                className={`px-3 py-1 rounded-full text-sm lg:text-base font-medium border border-zinc-200 dark:border-zinc-700 ${cc.text} hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-colors`}
-                title={sib.summary || sib.title}
+                className={`relative px-3 py-1 min-h-[44px] rounded-full text-sm lg:text-base font-medium border border-zinc-200 dark:border-zinc-700 ${cc.text} hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-colors`}
               >
                 {sib.title}
               </button>

--- a/src/components/learn/VibeScorePill.jsx
+++ b/src/components/learn/VibeScorePill.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkles } from 'lucide-react';
+import HoverTip from '../ui/HoverTip';
 
 /**
  * Compact VibeScore pill for the top nav. Shows the running total + the
@@ -28,22 +29,22 @@ export default function VibeScorePill({ score, level, onClick, ariaLabel }) {
       type="button"
       onClick={onClick}
       aria-label={ariaLabel || `VibeScore ${total}, level ${level?.current?.label || ''}`}
-      title="See your VibeScore breakdown"
-      className="relative inline-flex items-center gap-2 px-3 py-2 rounded-lg text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
+      className="group relative inline-flex items-center gap-2 min-h-[44px] px-3 py-2 rounded-lg text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
     >
       <Sparkles size={16} className="text-amber-500 shrink-0" />
       <span className="flex flex-col items-start leading-tight">
         <span className="text-sm font-bold text-zinc-900 dark:text-white tabular-nums">
           {total}
         </span>
-        <span className="hidden xl:inline text-[11px] uppercase tracking-wider text-zinc-500 dark:text-zinc-400 font-semibold">
+        <span className="hidden xl:inline text-xs uppercase tracking-wider text-zinc-500 dark:text-zinc-400 font-semibold">
           {level?.current?.label || 'Lurker'}
         </span>
       </span>
+      <HoverTip text="See your VibeScore breakdown" align="right" />
       {delta != null && (
         <span
           aria-hidden
-          className="pointer-events-none absolute -top-2 right-1 px-1.5 py-0.5 rounded-md text-[11px] font-bold bg-emerald-500 text-white shadow animate-fade-in"
+          className="pointer-events-none absolute -top-2 right-1 px-1.5 py-0.5 rounded-md text-xs font-bold bg-emerald-500 text-white shadow animate-fade-in"
         >
           +{delta}
         </span>

--- a/src/components/ui/DefinitionPanel.jsx
+++ b/src/components/ui/DefinitionPanel.jsx
@@ -38,7 +38,7 @@ export default function DefinitionPanel({
             onClick={() => setOpen((v) => !v)}
             aria-expanded={open}
             aria-controls="definition-details"
-            className={`mt-3 inline-flex items-center gap-1.5 text-sm lg:text-base font-semibold ${accent} hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900 ${categoryColors?.ring || 'focus-visible:ring-indigo-500'} rounded`}
+            className={`relative mt-3 inline-flex items-center gap-1.5 min-h-[44px] text-sm lg:text-base font-semibold ${accent} hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900 ${categoryColors?.ring || 'focus-visible:ring-indigo-500'} rounded`}
           >
             <span>{open ? 'Show less' : 'Read more about when to use this'}</span>
             <ChevronDown

--- a/src/components/ui/ExploreBar.jsx
+++ b/src/components/ui/ExploreBar.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import HoverTip from './HoverTip';
 import { Shuffle, Calendar, Trophy, ChevronDown, ChevronUp, RotateCcw, Check, Copy, Eye } from 'lucide-react';
 import { CATEGORY_COLORS } from '../../data/categories';
 import { useCategories } from '../../hooks/useCategories';
@@ -76,10 +77,12 @@ export default function ExploreBar({ explore, activeItem, onSelectItem, activeCa
 
           <button
             onClick={() => setExpanded(!expanded)}
-            className="p-1.5 rounded-lg text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-800 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-            title="View progress"
+            className="group relative flex items-center justify-center min-w-[44px] min-h-[44px] p-1.5 rounded-lg text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-800 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+            aria-label="View progress"
+            aria-expanded={expanded}
           >
             {expanded ? <ChevronUp size={16} /> : <Trophy size={16} />}
+            <HoverTip text="View progress" align="right" />
           </button>
         </div>
       </div>
@@ -143,7 +146,7 @@ export default function ExploreBar({ explore, activeItem, onSelectItem, activeCa
                                 ? `${cc.bg} ${cc.text} ${cc.border} border`
                                 : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 border border-transparent hover:bg-zinc-200 dark:hover:bg-zinc-700'
                             }`}
-                            title={isCopied ? 'Visited & copied' : isVisited ? 'Visited' : 'Not yet explored'}
+                            aria-label={`${item.name}, ${isCopied ? 'visited and copied' : isVisited ? 'visited' : 'not yet explored'}`}
                           >
                             {isCopied ? <Copy size={8} /> : isVisited ? <Eye size={8} /> : null}
                             {item.name}

--- a/src/components/ui/HoverTip.jsx
+++ b/src/components/ui/HoverTip.jsx
@@ -1,0 +1,26 @@
+/**
+ * In-app hover/focus tip for icon chrome. Decorative only: the control
+ * still needs aria-label. Never use a native title= for the same job.
+ */
+export default function HoverTip({
+  text,
+  align = 'left',
+  hideFrom,
+  hidden = false,
+}) {
+  if (!text || hidden) return null;
+  const alignClass = align === 'right'
+    ? 'right-0 left-auto'
+    : align === 'center'
+      ? 'left-1/2 -translate-x-1/2'
+      : 'left-0';
+  const hideClass = hideFrom === 'lg' ? 'lg:hidden' : hideFrom === 'xl' ? 'xl:hidden' : '';
+  return (
+    <span
+      role="tooltip"
+      className={`pointer-events-none absolute top-full mt-1.5 z-[60] ${alignClass} whitespace-nowrap max-w-[min(20rem,calc(100vw-2rem))] truncate px-3 py-2 rounded-lg text-sm font-semibold text-zinc-700 dark:text-zinc-200 bg-white dark:bg-zinc-800 border-2 border-zinc-300 dark:border-zinc-700 ring-1 ring-black/5 dark:ring-white/10 shadow-2xl opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${hideClass}`}
+    >
+      {text}
+    </span>
+  );
+}

--- a/src/data/releases.js
+++ b/src/data/releases.js
@@ -60,7 +60,7 @@ export const WHATS_NEW = [
     version: '0.10.0',
     date: '2026-08-17',
     tag: 'feature',
-    title: 'Optional accounts — back up your progress',
+    title: 'Optional accounts, back up your progress',
     blurb: 'Sign in with Google or email to keep your VibeScore, badges, and progress safe across devices. No account needed to use the site.',
     image: null,
     action: { kind: 'account' },

--- a/src/lib/topicUrl.js
+++ b/src/lib/topicUrl.js
@@ -1,0 +1,113 @@
+/**
+ * Shareable addresses for glossary and build-literacy topics.
+ *
+ * Canonical form is a path Firebase already rewrites to index.html:
+ *   /glossary/modal
+ *   /build/particle-field
+ *
+ * Also honors the URLs people already try: /components/:id, ?component=,
+ * ?topic=, #/glossary/:id, #particle-field. Proof links (#proof=) stay first.
+ */
+import { GLOSSARY_DATA } from '../data/glossary';
+import { getBuildTopic } from '../data/buildLiteracy';
+
+function decodeSlug(value) {
+  if (!value) return '';
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function matchSectionPath(path) {
+  const clean = String(path || '/').replace(/\/+$/, '') || '/';
+  const m = clean.match(/^\/(glossary|build|components)\/([^/]+)$/);
+  if (!m) return null;
+  const section = m[1] === 'components' ? 'glossary' : m[1];
+  return { section, id: decodeSlug(m[2]) };
+}
+
+export function isProofLocation(loc) {
+  const hash = loc?.hash || '';
+  return hash.startsWith('#proof=');
+}
+
+/**
+ * @param {Pick<Location, 'pathname' | 'search' | 'hash'>} loc
+ * @returns {{ type: 'proof' } | { type: 'topic', section: 'glossary' | 'build' | null, id: string } | { type: 'none' }}
+ */
+export function parseTopicLocation(loc) {
+  const location = loc || (typeof window !== 'undefined' ? window.location : { pathname: '/', search: '', hash: '' });
+  const hash = location.hash || '';
+  if (hash.startsWith('#proof=')) return { type: 'proof' };
+
+  const fromPath = matchSectionPath(location.pathname || '/');
+  if (fromPath) return { type: 'topic', ...fromPath };
+
+  const hashBody = hash.startsWith('#') ? hash.slice(1) : hash;
+  if (hashBody && !hashBody.startsWith('proof=')) {
+    const hashedPath = hashBody.startsWith('/') ? hashBody : `/${hashBody}`;
+    const fromHashPath = matchSectionPath(hashedPath);
+    if (fromHashPath) return { type: 'topic', ...fromHashPath };
+    if (hashBody && !hashBody.includes('=')) {
+      return { type: 'topic', section: null, id: decodeSlug(hashBody) };
+    }
+  }
+
+  const rawSearch = location.search || '';
+  const params = new URLSearchParams(rawSearch.startsWith('?') ? rawSearch.slice(1) : rawSearch);
+  const buildId = params.get('topic') || params.get('build') || params.get('b');
+  const glossaryId = params.get('component') || params.get('glossary') || params.get('g');
+  if (buildId) return { type: 'topic', section: 'build', id: decodeSlug(buildId) };
+  if (glossaryId) return { type: 'topic', section: 'glossary', id: decodeSlug(glossaryId) };
+
+  return { type: 'none' };
+}
+
+export function isGlossaryTopicId(id) {
+  return Boolean(id && GLOSSARY_DATA[id]);
+}
+
+export function isBuildTopicId(id) {
+  return Boolean(id && getBuildTopic(id));
+}
+
+/**
+ * Map a parsed location onto a real topic. A path that names the wrong
+ * catalog still opens the topic if the id exists in the other one, so
+ * /glossary/particle-field lands on the build topic instead of Modal.
+ */
+export function resolveTopicRef(parsed) {
+  if (!parsed || parsed.type !== 'topic' || !parsed.id) return null;
+  const { section, id } = parsed;
+  if (section === 'build' && isBuildTopicId(id)) return { section: 'build', id };
+  if (section === 'glossary' && isGlossaryTopicId(id)) return { section: 'glossary', id };
+  if (isBuildTopicId(id)) return { section: 'build', id };
+  if (isGlossaryTopicId(id)) return { section: 'glossary', id };
+  return null;
+}
+
+export function topicHref(section, id) {
+  if (!id) return '/';
+  const slug = encodeURIComponent(id);
+  return section === 'build' ? `/build/${slug}` : `/glossary/${slug}`;
+}
+
+export function syncTopicUrl(section, id, { replace = false } = {}) {
+  if (typeof window === 'undefined' || !id) return;
+  if (isProofLocation(window.location)) return;
+  const href = topicHref(section, id);
+  const currentPath = (window.location.pathname || '/').replace(/\/+$/, '') || '/';
+  const dirty = Boolean(window.location.search || (window.location.hash && !window.location.hash.startsWith('#proof=')));
+  if (currentPath === href) {
+    if (dirty) window.history.replaceState(null, '', href);
+    return;
+  }
+  window.history[replace ? 'replaceState' : 'pushState'](null, '', href);
+}
+
+export function topicFromWindow() {
+  if (typeof window === 'undefined') return null;
+  return resolveTopicRef(parseTopicLocation(window.location));
+}

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -101,6 +101,7 @@ const clampPanelWidth = (x, width) =>
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.classList.remove('dark');
+  window.history.replaceState(null, '', '/');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -183,5 +184,25 @@ describe('App smoke test', () => {
         render(<App />);
       })
     ).resolves.not.toThrow();
+  });
+});
+
+describe('shareable topic URLs', () => {
+  it('skips WelcomeScreen when the URL names a build topic', async () => {
+    window.history.replaceState(null, '', '/build/particle-field');
+    await act(async () => {
+      render(<App />);
+    });
+    expect(screen.queryByTestId('welcome-screen')).toBeNull();
+    expect(screen.getByTestId('top-nav')).toBeInTheDocument();
+  });
+
+  it('skips WelcomeScreen for /glossary/modal', async () => {
+    window.history.replaceState(null, '', '/glossary/modal');
+    await act(async () => {
+      render(<App />);
+    });
+    expect(screen.queryByTestId('welcome-screen')).toBeNull();
+    expect(screen.getByTestId('top-nav')).toBeInTheDocument();
   });
 });

--- a/src/test/ExploreBar.test.jsx
+++ b/src/test/ExploreBar.test.jsx
@@ -137,7 +137,7 @@ describe('expand/collapse progress panel', () => {
     const props = defaultProps();
     render(<ExploreBar {...props} />);
 
-    await user.click(screen.getByTitle('View progress'));
+    await user.click(screen.getByRole('button', { name: 'View progress' }));
 
     expect(screen.getByText('Your Progress')).toBeInTheDocument();
   });
@@ -147,7 +147,7 @@ describe('expand/collapse progress panel', () => {
     const props = defaultProps();
     render(<ExploreBar {...props} />);
 
-    const expandBtn = screen.getByTitle('View progress');
+    const expandBtn = screen.getByRole('button', { name: 'View progress' });
     await user.click(expandBtn);
     await user.click(expandBtn);
 
@@ -164,7 +164,7 @@ describe('expanded panel — category names', () => {
     const props = defaultProps();
     render(<ExploreBar {...props} />);
 
-    await user.click(screen.getByTitle('View progress'));
+    await user.click(screen.getByRole('button', { name: 'View progress' }));
 
     expect(CATEGORIES).toHaveLength(10);
 
@@ -184,7 +184,7 @@ describe('item pill clicks', () => {
     render(<ExploreBar {...props} />);
 
     // Expand the panel
-    await user.click(screen.getByTitle('View progress'));
+    await user.click(screen.getByRole('button', { name: 'View progress' }));
 
     // Find the "Popover" pill (it's in overlays, id = 'popover')
     const popoverPill = screen.getByRole('button', { name: /popover/i });
@@ -198,7 +198,7 @@ describe('item pill clicks', () => {
     const props = defaultProps();
     render(<ExploreBar {...props} />);
 
-    await user.click(screen.getByTitle('View progress'));
+    await user.click(screen.getByRole('button', { name: 'View progress' }));
 
     // "Tabs vs. Segments" is in navigation with id = 'tabs'
     const tabsPill = screen.getByRole('button', { name: /tabs vs\. segments/i });
@@ -218,7 +218,7 @@ describe('Reset button', () => {
     render(<ExploreBar {...props} />);
 
     // Expand to reveal the Reset button
-    await user.click(screen.getByTitle('View progress'));
+    await user.click(screen.getByRole('button', { name: 'View progress' }));
 
     await user.click(screen.getByRole('button', { name: /reset/i }));
 

--- a/src/test/releases.test.js
+++ b/src/test/releases.test.js
@@ -53,4 +53,11 @@ describe('What\'s New feed', () => {
   it('exposes the newest entry id for seen-state tracking', () => {
     expect(latestReleaseId()).toBe(WHATS_NEW[0].id);
   });
+
+  it('user-facing titles and blurbs have no em dashes', () => {
+    WHATS_NEW.forEach(entry => {
+      expect(entry.title, `${entry.id} title`).not.toMatch(/\u2014/);
+      expect(entry.blurb, `${entry.id} blurb`).not.toMatch(/\u2014/);
+    });
+  });
 });

--- a/src/test/topicUrl.test.js
+++ b/src/test/topicUrl.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTopicLocation,
+  resolveTopicRef,
+  topicHref,
+  isProofLocation,
+} from '../lib/topicUrl';
+
+const loc = (partial) => ({
+  pathname: '/',
+  search: '',
+  hash: '',
+  ...partial,
+});
+
+describe('parseTopicLocation', () => {
+  it('reads /glossary/:id and /build/:id', () => {
+    expect(parseTopicLocation(loc({ pathname: '/glossary/modal' }))).toEqual({
+      type: 'topic', section: 'glossary', id: 'modal',
+    });
+    expect(parseTopicLocation(loc({ pathname: '/build/particle-field' }))).toEqual({
+      type: 'topic', section: 'build', id: 'particle-field',
+    });
+  });
+
+  it('treats /components/:id as a glossary path', () => {
+    expect(parseTopicLocation(loc({ pathname: '/components/drawer' }))).toEqual({
+      type: 'topic', section: 'glossary', id: 'drawer',
+    });
+  });
+
+  it('honors query strings people already try', () => {
+    expect(parseTopicLocation(loc({ search: '?component=modal' }))).toEqual({
+      type: 'topic', section: 'glossary', id: 'modal',
+    });
+    expect(parseTopicLocation(loc({ search: '?topic=particle-field' }))).toEqual({
+      type: 'topic', section: 'build', id: 'particle-field',
+    });
+  });
+
+  it('honors hash paths and a bare hash id', () => {
+    expect(parseTopicLocation(loc({ hash: '#/build/particle-field' }))).toEqual({
+      type: 'topic', section: 'build', id: 'particle-field',
+    });
+    expect(parseTopicLocation(loc({ hash: '#particle-field' }))).toEqual({
+      type: 'topic', section: null, id: 'particle-field',
+    });
+  });
+
+  it('leaves #proof= links alone', () => {
+    const proof = loc({ hash: '#proof=abc' });
+    expect(parseTopicLocation(proof)).toEqual({ type: 'proof' });
+    expect(isProofLocation(proof)).toBe(true);
+  });
+
+  it('returns none for the home path', () => {
+    expect(parseTopicLocation(loc({ pathname: '/' }))).toEqual({ type: 'none' });
+  });
+});
+
+describe('resolveTopicRef', () => {
+  it('opens a build topic even when the path said glossary', () => {
+    expect(resolveTopicRef({ type: 'topic', section: 'glossary', id: 'particle-field' })).toEqual({
+      section: 'build', id: 'particle-field',
+    });
+  });
+
+  it('opens a glossary topic from a bare hash', () => {
+    expect(resolveTopicRef({ type: 'topic', section: null, id: 'modal' })).toEqual({
+      section: 'glossary', id: 'modal',
+    });
+  });
+
+  it('returns null for an unknown id', () => {
+    expect(resolveTopicRef({ type: 'topic', section: 'glossary', id: 'not-a-real-topic' })).toBeNull();
+  });
+});
+
+describe('topicHref', () => {
+  it('builds the canonical shareable path', () => {
+    expect(topicHref('glossary', 'modal')).toBe('/glossary/modal');
+    expect(topicHref('build', 'particle-field')).toBe('/build/particle-field');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes live VibeGlossary issues #13-19 against DESIGN.md and CLAUDE.md. Motion landing, ParticleField, and the reduced-motion hero.png path are untouched.

- **#13** Shareable topic URLs: `/glossary/:id` and `/build/:id`, plus `/components/:id`, `?component=`, `?topic=`, and hash fallbacks. Wrong-catalog paths still open the real topic. Welcome is skipped when the URL names a topic. `#proof=` stays first. Cite: CLAUDE.md teaching audience (a glossary you cannot link is not teachable). DESIGN.md Layout.
- **#14** Settings menu closes on Escape and after Dark Mode. Popovers use opaque raised-card surfaces (`bg-white` / `dark:bg-zinc-800`). Cite: DESIGN.md Dropdowns and Color palette.
- **#15** Header titles cannot overprint What's New / VibeScore. Left cluster shrinks and overflows; right chrome stays `z-20`. Cite: DESIGN.md Layout.
- **#16** Cmd-K and LURKER are `text-xs`. Cite: DESIGN.md Minimum readable sizes.
- **#17** Native `title=` replaced with in-app HoverTip plus aria-label on header/chrome. Cite: DESIGN.md Icon actions and tips.
- **#18** Em dashes removed from What's New and sign-in copy. Cite: DESIGN.md Tone and voice.
- **#19** 44px tap targets with compact visuals. Quiz me, arrows, and search are not fat pills. Cite: DESIGN.md Buttons / Accessibility; CLAUDE.md touch targets.

## Test plan
- [ ] Open `/build/particle-field` (and `/glossary/particle-field`, `/?topic=particle-field`). Reloads that topic, not Modal.
- [ ] What's New -> Motion language leaves a copyable URL.
- [ ] Menu -> Settings -> Dark Mode closes; Escape closes; light popover is opaque.
- [ ] 1440x900 long titles do not cover What's New / VibeScore / LURKER.
- [ ] Cmd-K and LURKER are text-xs or larger.
- [ ] Header icons show in-app tips, not native title=.
- [ ] What's New + sign-in copy have no em dashes.
- [ ] Search, arrows, Quiz me, chips, Read more: 44px hit, compact paint.

`npm test`: 1269 passed (18 files). Not deployed. This host has no PR preview, so Tess needs a deploy after merge to re-test live, or local `npm run dev`.

Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19