### PR TITLE
fix: Quiz me hit box, em dashes, Visited title= (#21 #22 #23)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -573,17 +573,22 @@ export default function App() {
                         {showQuiz ? 'Learn Mode' : 'Definition'}
                       </span>
                       <button
+                        type="button"
                         onClick={toggleLearnMode}
                         aria-pressed={learnMode}
                         aria-label={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each component)'}
-                        className={`group relative ml-1 inline-flex items-center gap-1.5 px-2.5 py-1 before:absolute before:inset-y-[-8px] before:inset-x-[-4px] before:content-[''] rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
-                          learnMode
-                            ? 'bg-indigo-600 border-indigo-600 text-white hover:bg-indigo-500'
-                            : 'bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-                        }`}
+                        className="group relative ml-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent"
                       >
-                        <GraduationCap size={13} />
-                        {learnMode ? 'Learn Mode: On' : 'Quiz me'}
+                        <span
+                          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
+                            learnMode
+                              ? 'bg-indigo-600 border-indigo-600 text-white group-hover:bg-indigo-500'
+                              : 'bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800'
+                          }`}
+                        >
+                          <GraduationCap size={13} />
+                          {learnMode ? 'Learn Mode: On' : 'Quiz me'}
+                        </span>
                         <HoverTip text={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each component)'} />
                       </button>
                       <TopicTierBadge tier={explore.tiers?.[activeItem]} className="ml-1" />

--- a/src/components/learn/BuildTopicView.jsx
+++ b/src/components/learn/BuildTopicView.jsx
@@ -100,14 +100,18 @@ export default function BuildTopicView({
               onClick={toggleLearnMode}
               aria-pressed={learnMode}
               aria-label={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each topic)'}
-              className={`group relative ml-1 inline-flex items-center gap-1.5 px-2.5 py-1 before:absolute before:inset-y-[-8px] before:inset-x-[-4px] before:content-[''] rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
-                learnMode
-                  ? 'bg-indigo-600 border-indigo-600 text-white hover:bg-indigo-500'
-                  : 'bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-              }`}
+              className="group relative ml-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent"
             >
-              <GraduationCap size={13} />
-              {learnMode ? 'Learn Mode: On' : 'Quiz me'}
+              <span
+                className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs lg:text-sm font-semibold border transition-colors ${
+                  learnMode
+                    ? 'bg-indigo-600 border-indigo-600 text-white group-hover:bg-indigo-500'
+                    : 'bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800'
+                }`}
+              >
+                <GraduationCap size={13} />
+                {learnMode ? 'Learn Mode: On' : 'Quiz me'}
+              </span>
               <HoverTip text={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each topic)'} />
             </button>
             <TopicTierBadge

--- a/src/components/learn/ScoreBreakdownModal.jsx
+++ b/src/components/learn/ScoreBreakdownModal.jsx
@@ -101,7 +101,7 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onO
               <span className="text-sm text-zinc-500 dark:text-zinc-400">
                 {next
                   ? `${level.pointsToNext} pts to ${next.label}`
-                  : 'Top rung — keep retaining what you know.'}
+                  : 'Top rung. Keep retaining what you know.'}
               </span>
             </div>
             <div className="h-2.5 rounded-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">

--- a/src/components/learn/TalkToAiCard.jsx
+++ b/src/components/learn/TalkToAiCard.jsx
@@ -138,18 +138,20 @@ function PromptPanel({ kind, label, sub, icon, text, cc, divider }) {
           type="button"
           onClick={handleCopy}
           disabled={!text}
-          className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold text-zinc-300 bg-zinc-800 hover:bg-zinc-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative shrink-0 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent disabled:opacity-40 disabled:cursor-not-allowed"
           aria-label={`Copy ${label}`}
         >
-          {copied ? (
-            <>
-              <Check size={14} className="text-emerald-400" /> Copied
-            </>
-          ) : (
-            <>
-              <Copy size={14} /> Copy
-            </>
-          )}
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold text-zinc-300 bg-zinc-800 group-hover:bg-zinc-700 transition-colors">
+            {copied ? (
+              <>
+                <Check size={14} className="text-emerald-400" /> Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy
+              </>
+            )}
+          </span>
         </button>
       </div>
 

--- a/src/components/learn/TopicTierBadge.jsx
+++ b/src/components/learn/TopicTierBadge.jsx
@@ -1,4 +1,5 @@
 import { Eye, ClipboardCopy, GraduationCap, Award, Repeat } from 'lucide-react';
+import HoverTip from '../ui/HoverTip';
 
 /**
  * Tiered status pill for a single topic. Replaces the binary "Mastered"
@@ -45,11 +46,15 @@ export default function TopicTierBadge({ tier, className = '' }) {
 
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold uppercase tracking-wider border ${meta.classes} ${className}`}
-      title={meta.next}
+      tabIndex={0}
+      className={`group relative inline-flex items-center ${className}`}
+      aria-label={`${labelText}. ${meta.next}`}
     >
-      <Icon size={11} className="shrink-0" />
-      {labelText}
+      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold uppercase tracking-wider border ${meta.classes}`}>
+        <Icon size={11} className="shrink-0" aria-hidden />
+        {labelText}
+      </span>
+      <HoverTip text={meta.next} />
     </span>
   );
 }

--- a/src/components/ui/PromptBuilder.jsx
+++ b/src/components/ui/PromptBuilder.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Terminal, Zap, CheckSquare, Square, Check, Copy, Code2, ShieldCheck, ChevronDown } from 'lucide-react';
+import HoverTip from './HoverTip';
 
 const FRAMEWORKS = [
   { id: 'shadcn', label: 'shadcn/ui' },
@@ -222,11 +223,15 @@ export default function PromptBuilder({ data, activeOptions, onOptionToggle, cat
           ))}
         </div>
         <button
+          type="button"
           onClick={handleCopy}
-          className="absolute top-2.5 right-2.5 p-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 rounded-lg text-zinc-500 transition-colors opacity-0 group-hover/code:opacity-100"
-          title="Copy to clipboard (markdown)"
+          className="group absolute top-1 right-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent text-zinc-500 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100"
+          aria-label="Copy to clipboard (markdown)"
         >
-          {copied ? <Check size={16} className="text-emerald-500" /> : <Copy size={16} />}
+          <span className="p-2 rounded-lg bg-zinc-100 dark:bg-zinc-800 group-hover:bg-zinc-200 dark:group-hover:bg-zinc-700">
+            {copied ? <Check size={16} className="text-emerald-500" /> : <Copy size={16} />}
+          </span>
+          <HoverTip text="Copy to clipboard" align="right" />
         </button>
       </div>
     </div>

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -7,24 +7,7 @@ import {
   signOut as firebaseSignOut,
 } from 'firebase/auth';
 import { auth, googleProvider } from '../firebase';
-
-// Friendly copy for the Firebase error codes users can actually hit.
-// A `null` value means "stay silent" (e.g. they closed the popup on purpose).
-const ERROR_COPY = {
-  'auth/invalid-credential': 'Wrong email or password.',
-  'auth/user-not-found': 'No account with that email — try "Create an account".',
-  'auth/wrong-password': 'Wrong email or password.',
-  'auth/email-already-in-use': 'That email already has an account — sign in instead.',
-  'auth/weak-password': 'Password needs at least 6 characters.',
-  'auth/invalid-email': "That doesn't look like a valid email.",
-  'auth/too-many-requests': 'Too many tries — wait a minute and try again.',
-  'auth/popup-blocked': 'Your browser blocked the popup — allow popups and try again.',
-  'auth/popup-closed-by-user': null,
-  'auth/cancelled-popup-request': null,
-  'auth/operation-not-allowed': "Sign-in isn't enabled yet — try again later.",
-  'auth/configuration-not-found': "Sign-in isn't enabled yet — try again later.",
-  'auth/network-request-failed': 'Network hiccup — check your connection and try again.',
-};
+import { AUTH_ERROR_COPY, AUTH_ERROR_FALLBACK } from '../lib/authErrors';
 
 /**
  * Optional account state. Signing in is never required — it only exists so
@@ -48,11 +31,11 @@ export default function useAuth() {
       await action();
       return true;
     } catch (err) {
-      const known = Object.prototype.hasOwnProperty.call(ERROR_COPY, err?.code);
+      const known = Object.prototype.hasOwnProperty.call(AUTH_ERROR_COPY, err?.code);
       if (!known) console.error('[auth] unmapped error:', err?.code, err);
       const copy = known
-        ? ERROR_COPY[err.code]
-        : 'Something went wrong — please try again.';
+        ? AUTH_ERROR_COPY[err.code]
+        : AUTH_ERROR_FALLBACK;
       if (copy) setError(copy);
       return false;
     } finally {

--- a/src/lib/authErrors.js
+++ b/src/lib/authErrors.js
@@ -1,0 +1,24 @@
+// Friendly copy for the Firebase error codes users can actually hit.
+// A null value means stay silent (e.g. they closed the popup on purpose).
+export const AUTH_ERROR_COPY = {
+  'auth/invalid-credential': 'Wrong email or password.',
+  'auth/user-not-found': 'No account with that email. Try "Create an account".',
+  'auth/wrong-password': 'Wrong email or password.',
+  'auth/email-already-in-use': 'That email already has an account. Sign in instead.',
+  'auth/weak-password': 'Password needs at least 6 characters.',
+  'auth/invalid-email': "That doesn't look like a valid email.",
+  'auth/too-many-requests': 'Too many tries. Wait a minute and try again.',
+  'auth/popup-blocked': 'Your browser blocked the popup. Allow popups and try again.',
+  'auth/popup-closed-by-user': null,
+  'auth/cancelled-popup-request': null,
+  'auth/operation-not-allowed': "Sign-in isn't enabled yet. Try again later.",
+  'auth/configuration-not-found': "Sign-in isn't enabled yet. Try again later.",
+  'auth/network-request-failed': 'Network hiccup. Check your connection and try again.',
+};
+
+export const AUTH_ERROR_FALLBACK = 'Something went wrong. Please try again.';
+
+export function authErrorMessage(code) {
+  const known = Object.prototype.hasOwnProperty.call(AUTH_ERROR_COPY, code);
+  return known ? AUTH_ERROR_COPY[code] : AUTH_ERROR_FALLBACK;
+}

--- a/src/test/PromptBuilder.test.jsx
+++ b/src/test/PromptBuilder.test.jsx
@@ -215,7 +215,7 @@ describe('PromptBuilder', () => {
       />
     );
 
-    await user.click(screen.getByTitle('Copy to clipboard (markdown)'));
+    await user.click(screen.getByRole('button', { name: 'Copy to clipboard (markdown)' }));
 
     expect(writeTextSpy).toHaveBeenCalledWith(
       expect.stringContaining('Add a centered Dialog modal overlay')
@@ -233,7 +233,7 @@ describe('PromptBuilder', () => {
       />
     );
 
-    await user.click(screen.getByTitle('Copy to clipboard (markdown)'));
+    await user.click(screen.getByRole('button', { name: 'Copy to clipboard (markdown)' }));
     expect(onCopy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/test/chromeLeftovers.test.jsx
+++ b/src/test/chromeLeftovers.test.jsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import TopicTierBadge from '../components/learn/TopicTierBadge';
+import TalkToAiCard from '../components/learn/TalkToAiCard';
+import PromptBuilder from '../components/ui/PromptBuilder';
+import ScoreBreakdownModal from '../components/learn/ScoreBreakdownModal';
+import BuildTopicView from '../components/learn/BuildTopicView';
+import { AUTH_ERROR_COPY, AUTH_ERROR_FALLBACK } from '../lib/authErrors';
+import { levelFor } from '../lib/scoring';
+
+const topic = {
+  id: 'particle-field',
+  title: 'Particle Field',
+  summary: 'Wallpaper behind the page.',
+  definition: 'Wallpaper behind the page.',
+  talkToAi: { starter: 'Hello starter', example: 'Hello example' },
+};
+
+describe('#21 Quiz me and Copy keep compact paint and a 44px hit box', () => {
+  it('Quiz me button is 44px tall while the chip stays compact', () => {
+    render(
+      <BuildTopicView
+        topic={topic}
+        cluster={{ id: 'design-language', title: 'Design language', topics: [topic] }}
+        glossary={{}}
+        learnMode={false}
+        toggleLearnMode={() => {}}
+        quizPool={[]}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /Turn on Learn Mode/i });
+    expect(btn.className).toMatch(/min-h-\[44px\]/);
+    expect(btn.className).not.toMatch(/bg-indigo-600/);
+    const paint = btn.querySelector('span.rounded-full');
+    expect(paint).toBeTruthy();
+    expect(paint.className).toMatch(/py-1/);
+    expect(paint.className).not.toMatch(/min-h-\[44px\]/);
+    expect(paint.textContent).toMatch(/Quiz me/);
+  });
+
+  it('Talk to AI Copy chip sits in a 44px hit box', () => {
+    render(<TalkToAiCard topic={topic} />);
+    const copies = screen.getAllByRole('button', { name: /Copy /i });
+    expect(copies.length).toBeGreaterThan(0);
+    copies.forEach((btn) => {
+      expect(btn.className).toMatch(/min-h-\[44px\]/);
+      const paint = btn.querySelector('span');
+      expect(paint.className).not.toMatch(/min-h-\[44px\]/);
+    });
+  });
+
+  it('Spec Generator Copy uses a 44px hit box and no title=', () => {
+    render(
+      <PromptBuilder
+        data={{
+          prompt: {
+            base: 'Add a dialog',
+            options: [],
+            requirements: [],
+            scaffolds: { shadcn: '<Dialog />' },
+          },
+        }}
+        activeOptions={new Set()}
+        onOptionToggle={() => {}}
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'Copy to clipboard (markdown)' });
+    expect(btn).not.toHaveAttribute('title');
+    expect(btn.className).toMatch(/min-h-\[44px\]/);
+  });
+});
+
+describe('#22 no em dashes in VibeScore or auth errors', () => {
+  it('auth error strings use periods, not em dashes', () => {
+    const values = [...Object.values(AUTH_ERROR_COPY), AUTH_ERROR_FALLBACK];
+    values.filter(Boolean).forEach((copy) => {
+      expect(copy, copy).not.toMatch(/\u2014/);
+      expect(copy, copy).not.toMatch(/\u2013/);
+    });
+  });
+
+  it('top-rung VibeScore copy has no em dash', () => {
+    const score = {
+      total: 2000,
+      glossary: { total: 1000, visited: 10, used: 0, passed: 0, mastered: 0, retained: 0, pathBonus: 0 },
+      build: { total: 1000, visited: 10, used: 0, passed: 0, mastered: 0, retained: 0, pathBonus: 0 },
+    };
+    render(
+      <ScoreBreakdownModal
+        isOpen
+        onClose={() => {}}
+        score={score}
+        level={levelFor(2000)}
+      />
+    );
+    expect(screen.getByText(/Top rung/)).toBeInTheDocument();
+    expect(screen.getByText(/Top rung/).textContent).not.toMatch(/\u2014/);
+    expect(screen.getByText(/Top rung/).textContent).toMatch(/Keep retaining what you know/);
+  });
+});
+
+describe('#23 Visited badge uses HoverTip, not title=', () => {
+  it('exposes the next-rung hint via aria-label and in-app tip', () => {
+    render(<TopicTierBadge tier={{ visited: true }} />);
+    const badge = screen.getByLabelText(/Visited/);
+    expect(badge).not.toHaveAttribute('title');
+    expect(badge.getAttribute('aria-label')).toMatch(/Copy a prompt to reach Used/);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Copy a prompt to reach Used.');
+  });
+});


### PR DESCRIPTION
## Summary
- **#21 Quiz me / Copy:** 44px hit box via `min-h-[44px]` on the control, compact painted chip inside (`py-1`, not a fat labeled pill). Same treatment on Talk to AI Copy and Spec Generator Copy. DESIGN.md Buttons / Accessibility: 44px is the hit box, visual may be 32 to 40px. CLAUDE.md touch targets >=44px.
- **#22 Em dashes:** Remaining user-facing strings in VibeScore top-rung copy and auth errors now use periods. DESIGN.md Tone and voice: no em dashes in user-facing copy.
- **#23 Visited title=:** TopicTierBadge drops native `title=`. In-app HoverTip plus `aria-label` for the next-rung hint. DESIGN.md Icon actions and tips: in-app hover and focus tip, not a native title=.

Tess can re-test chrome leftovers on this PR separate from the motion demo PR.

## Test plan
- [ ] `/build/particle-field`: Quiz me chip still looks compact (~30px paint) but inspect hit box is 44px tall
- [ ] Talk to AI Copy and Spec Generator Copy are 44px hit, compact paint
- [ ] Hover VISITED: in-app tip, no native browser tooltip
- [ ] VibeScore top rung and a forced auth error have no em dashes
- [ ] `npx vitest run src/test/chromeLeftovers.test.jsx`