### PR TITLE
fix: real easing compare and motion pattern demos (#24 #25)

### DIFF
--- a/src/components/demos/MotionPatternDemo.jsx
+++ b/src/components/demos/MotionPatternDemo.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 function prefersReducedMotion() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
@@ -9,7 +9,7 @@ function prefersReducedMotion() {
   }
 }
 
-function Frame({ title, children }) {
+function Frame({ title, children, fill = false }) {
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-zinc-50/80 dark:bg-zinc-950/40">
       <div className="shrink-0 border-b border-zinc-200/80 px-4 pb-3 pt-4 dark:border-zinc-800/80 sm:px-6">
@@ -18,67 +18,446 @@ function Frame({ title, children }) {
         </p>
         <p className="truncate text-sm font-semibold text-zinc-800 dark:text-zinc-100">{title}</p>
       </div>
-      <div className="flex flex-1 items-center justify-center overflow-hidden p-6 sm:p-10">
+      <div className={`flex min-h-0 flex-1 overflow-auto p-4 sm:p-6 ${fill ? 'items-stretch' : 'items-center justify-center'}`}>
         {children}
       </div>
     </div>
   );
 }
 
-function ParticlePreview({ reduced }) {
-  const dots = Array.from({ length: reduced ? 18 : 36 }, (_, i) => i);
+function ChipButton({ onClick, pressed, children, label }) {
   return (
-    <div className="relative h-48 w-full max-w-md overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 dark:border-zinc-700">
-      {dots.map((i) => (
-        <span
-          key={i}
-          className={`absolute h-1.5 w-1.5 rounded-full bg-indigo-400/80 ${reduced ? '' : 'vg-bob'}`}
-          style={{
-            left: `${8 + ((i * 37) % 84)}%`,
-            top: `${12 + ((i * 53) % 76)}%`,
-            '--bob': `${(i % 6) * 0.2}s`,
-            '--bob-d': `${4 + (i % 3)}s`,
-          }}
-        />
-      ))}
-      <p className="absolute inset-x-0 bottom-4 text-center text-sm font-semibold text-zinc-100">
-        Wallpaper. The page still reads.
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={pressed}
+      aria-label={label}
+      className="group inline-flex min-h-[44px] items-center justify-center bg-transparent px-1"
+    >
+      <span className={`inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-semibold transition-colors ${
+        pressed
+          ? 'border-indigo-600 bg-indigo-600 text-white'
+          : 'border-zinc-200 bg-white text-zinc-700 group-hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200'
+      }`}
+      >
+        {children}
+      </span>
+    </button>
+  );
+}
+
+function kick(setGo) {
+  setGo(false);
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => setGo(true));
+  });
+}
+
+const EASING_TRAVELERS = [
+  { id: 'ease-out', label: 'Ease-out', timing: 'ease-out' },
+  { id: 'ease-in', label: 'Ease-in', timing: 'ease-in' },
+  { id: 'linear', label: 'Linear', timing: 'linear' },
+];
+
+function EasingPreview({ reduced }) {
+  const [go, setGo] = useState(false);
+  const [slow, setSlow] = useState(false);
+  const ms = reduced ? 0 : (slow ? 1200 : 300);
+
+  const replay = useCallback(() => kick(setGo), []);
+  useEffect(() => { replay(); }, [replay, slow, reduced]);
+
+  return (
+    <div className="w-full max-w-lg space-y-4">
+      <div className="flex flex-wrap items-center gap-1">
+        <ChipButton onClick={replay} label="Replay easing compare">Replay</ChipButton>
+        <ChipButton onClick={() => setSlow((v) => !v)} pressed={slow} label="Toggle slow motion">
+          {slow ? 'Slow-mo on' : 'Slow-mo'}
+        </ChipButton>
+      </div>
+      <div className="space-y-3">
+        {EASING_TRAVELERS.map((t) => (
+          <div key={t.id}>
+            <p className="mb-1 text-sm font-semibold text-zinc-800 dark:text-zinc-100">{t.label}</p>
+            <div className="relative h-10 w-full rounded-full bg-zinc-200 dark:bg-zinc-800">
+              <span
+                data-easing={t.id}
+                data-timing={t.timing}
+                data-duration-ms={String(ms)}
+                className="absolute top-1 h-8 w-8 rounded-full bg-indigo-600 shadow-sm"
+                style={{
+                  left: go ? 'calc(100% - 2.25rem)' : '0.25rem',
+                  transitionProperty: 'left',
+                  transitionDuration: `${ms}ms`,
+                  transitionTimingFunction: t.timing,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+        Same distance, same {slow ? '1200ms' : '300ms'}. Ease-out gets there fast then settles. Ease-in creeps then rushes. Linear almost never feels right.
       </p>
     </div>
   );
 }
 
-function EasingPreview({ reduced }) {
+function ParticlePreview({ reduced }) {
+  const [on, setOn] = useState(true);
+  const dots = Array.from({ length: 28 }, (_, i) => i);
   return (
-    <div className="w-full max-w-sm space-y-4">
-      {['ease-out', 'ease-in', 'linear'].map((name) => (
-        <div key={name}>
-          <p className="mb-1 text-xs font-bold uppercase tracking-wider text-zinc-500">{name}</p>
-          <div className="h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
-            <div
-              className={`h-full w-1/3 rounded-full bg-indigo-600 ${reduced ? '' : 'vg-bob'}`}
-              style={{ '--bob-d': name === 'linear' ? '2s' : '2.6s' }}
-            />
-          </div>
+    <div className="w-full max-w-lg space-y-3">
+      <ChipButton onClick={() => setOn((v) => !v)} pressed={on} label={on ? 'Hide particles' : 'Show particles'}>
+        {on ? 'Particles on' : 'Particles off'}
+      </ChipButton>
+      <div className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 px-6 py-8 dark:border-zinc-700">
+        {on && dots.map((i) => (
+          <span
+            key={i}
+            aria-hidden
+            data-particle-dot=""
+            className={`pointer-events-none absolute h-1.5 w-1.5 rounded-full bg-indigo-400/70 ${reduced ? '' : 'animate-pulse'}`}
+            style={{
+              left: `${8 + ((i * 37) % 84)}%`,
+              top: `${10 + ((i * 53) % 78)}%`,
+              animationDelay: reduced ? undefined : `${(i % 7) * 0.15}s`,
+            }}
+          />
+        ))}
+        <div className="relative z-10 space-y-2">
+          <h3 className="text-xl font-extrabold tracking-tight text-white">The page still reads</h3>
+          <p className="max-w-sm text-sm leading-relaxed text-zinc-200">
+            Headline and body sit on top of the field. Toggle the dots off. The words do not depend on them.
+          </p>
         </div>
-      ))}
+      </div>
+    </div>
+  );
+}
+
+function ParallaxPreview({ reduced }) {
+  const scroller = useRef(null);
+  const [scroll, setScroll] = useState(0);
+  const layers = [
+    { speed: 0.2, label: '0.2 far', cls: 'bg-zinc-300/90 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-100' },
+    { speed: 0.6, label: '0.6 mid', cls: 'bg-indigo-200/90 text-indigo-950 dark:bg-indigo-800 dark:text-indigo-50' },
+    { speed: 1.0, label: '1.0 near', cls: 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-800 dark:text-zinc-100' },
+  ];
+  return (
+    <div className="w-full max-w-lg space-y-3">
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+        Scroll the mini page. Far layers lag. Near layers keep up.
+      </p>
+      <div
+        ref={scroller}
+        data-parallax-scroller=""
+        onScroll={(e) => setScroll(e.currentTarget.scrollTop)}
+        className="relative h-56 overflow-y-auto rounded-2xl border border-zinc-200 bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        <div className="relative h-[420px] px-4 pt-6">
+          {layers.map((l, i) => (
+            <div
+              key={l.speed}
+              data-parallax-speed={String(l.speed)}
+              className={`absolute left-4 right-4 rounded-xl px-4 py-3 text-sm font-semibold ${l.cls}`}
+              style={{
+                top: 20 + i * 56,
+                transform: reduced ? 'none' : `translateY(${scroll * (1 - l.speed)}px)`,
+              }}
+            >
+              Speed {l.label}
+            </div>
+          ))}
+          <p className="absolute bottom-6 left-4 right-4 text-sm text-zinc-500 dark:text-zinc-400">
+            Keep scrolling. The stack pulls apart.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }
 
 function StaggerPreview({ reduced }) {
+  const items = [
+    { label: 'Inbox', delay: 0 },
+    { label: 'Drafts', delay: 50 },
+    { label: 'Sent', delay: 100 },
+  ];
+  const [mode, setMode] = useState('stagger');
+  const [go, setGo] = useState(false);
+  const replay = useCallback(() => kick(setGo), []);
+  useEffect(() => { replay(); }, [replay, mode]);
+
   return (
-    <ul className="w-full max-w-xs space-y-2">
-      {['Inbox', 'Drafts', 'Sent'].map((label, i) => (
-        <li
-          key={label}
-          className={`rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm font-semibold text-zinc-800 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 ${reduced ? '' : 'vg-reveal is-in'}`}
-          style={reduced ? undefined : { animationDelay: `${i * 50}ms`, transitionDelay: `${i * 50}ms` }}
+    <div className="w-full max-w-sm space-y-3">
+      <div className="flex flex-wrap items-center gap-1">
+        <ChipButton onClick={() => setMode('together')} pressed={mode === 'together'} label="Play all at once">
+          All at once
+        </ChipButton>
+        <ChipButton onClick={() => setMode('stagger')} pressed={mode === 'stagger'} label="Play 50 millisecond stagger">
+          50ms stagger
+        </ChipButton>
+        <ChipButton onClick={replay} label="Replay stagger">Replay</ChipButton>
+      </div>
+      <ul className="space-y-2">
+        {items.map((row) => {
+          const delay = mode === 'stagger' && !reduced ? row.delay : 0;
+          return (
+            <li
+              key={row.label}
+              data-stagger-row={row.label}
+              data-stagger-delay={`${delay}ms`}
+              className="flex items-center justify-between rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm font-semibold text-zinc-800 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+              style={{
+                opacity: go ? 1 : 0,
+                transform: go ? 'translateY(0)' : 'translateY(12px)',
+                transitionProperty: 'opacity, transform',
+                transitionDuration: reduced ? '0ms' : '300ms',
+                transitionTimingFunction: 'ease-out',
+                transitionDelay: `${delay}ms`,
+              }}
+            >
+              <span>{row.label}</span>
+              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{delay}ms</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function ScrollRevealPreview({ reduced }) {
+  const rootRef = useRef(null);
+  const [visible, setVisible] = useState({});
+  const [nonce, setNonce] = useState(0);
+  const cards = ['Nav bar', 'Hero', 'Pricing', 'Footer'];
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    if (reduced || typeof IntersectionObserver === 'undefined') {
+      setVisible(Object.fromEntries(cards.map((c) => [c, true])));
+      return undefined;
+    }
+    setVisible({});
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          const id = e.target.getAttribute('data-reveal-card');
+          if (id) setVisible((v) => ({ ...v, [id]: true }));
+        }
+      });
+    }, { root, threshold: 0.45 });
+    root.querySelectorAll('[data-reveal-card]').forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, [nonce, reduced]);
+
+  function reset() {
+    if (rootRef.current) rootRef.current.scrollTop = 0;
+    setVisible({});
+    setNonce((n) => n + 1);
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-3">
+      <ChipButton onClick={reset} label="Reset scroll reveal">Reset</ChipButton>
+      <div
+        ref={rootRef}
+        data-scroll-reveal=""
+        className="h-56 overflow-y-auto rounded-2xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        <p className="sticky top-0 z-10 border-b border-dashed border-indigo-400 bg-indigo-50/95 px-4 py-2 text-sm font-semibold text-indigo-900 dark:bg-indigo-950/95 dark:text-indigo-100">
+          Cards rise as they cross this line
+        </p>
+        <div className="space-y-3 p-4">
+          <div className="h-16" aria-hidden />
+          {cards.map((c) => {
+            const on = !!visible[c];
+            return (
+              <article
+                key={`${c}-${nonce}`}
+                data-reveal-card={c}
+                className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-4 text-sm font-semibold text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                style={{
+                  opacity: on ? 1 : 0,
+                  transform: on ? 'translateY(0)' : 'translateY(16px)',
+                  transition: reduced ? 'none' : 'opacity 400ms ease-out, transform 400ms ease-out',
+                }}
+              >
+                {c}
+              </article>
+            );
+          })}
+          <div className="h-20" aria-hidden />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToastCard({ instant, show, panel }) {
+  return (
+    <div
+      data-motion-panel={panel}
+      data-instant={instant ? 'true' : 'false'}
+      className="rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm font-semibold text-zinc-800 shadow-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+      style={{
+        opacity: show ? 1 : 0,
+        transform: show ? 'translateY(0)' : (instant ? 'translateY(0)' : 'translateY(12px)'),
+        transition: instant ? 'none' : 'opacity 200ms ease-out, transform 200ms ease-out',
+      }}
+    >
+      Draft saved
+    </div>
+  );
+}
+
+function ReducedMotionPreview({ reduced }) {
+  const [show, setShow] = useState(false);
+  const replay = useCallback(() => kick(setShow), []);
+  useEffect(() => { replay(); }, [replay]);
+
+  return (
+    <div className="w-full max-w-lg space-y-4">
+      <div className="flex flex-wrap items-center gap-1">
+        <ChipButton onClick={replay} label="Replay reduced motion compare">Replay</ChipButton>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="space-y-2 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-700">
+          <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Motion on</p>
+          <ToastCard panel="motion" instant={reduced} show={show} />
+        </div>
+        <div className="space-y-2 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-700">
+          <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Reduced</p>
+          <ToastCard panel="reduced" instant show={show} />
+        </div>
+      </div>
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+        {reduced
+          ? 'Your OS asked for reduced motion, so both toasts appear at once. The information stays. The travel is gone.'
+          : 'Same toast. Motion on slides in. Reduced is instant. Do not just shorten the same loop.'}
+      </p>
+    </div>
+  );
+}
+
+function PageTransitionPreview({ reduced }) {
+  const [screen, setScreen] = useState('list');
+  const [slow, setSlow] = useState(false);
+  const [phase, setPhase] = useState('in');
+  const ms = reduced ? 0 : (slow ? 900 : 200);
+
+  function goTo(next) {
+    if (reduced) {
+      setScreen(next);
+      setPhase('in');
+      return;
+    }
+    setPhase('out');
+    window.setTimeout(() => {
+      setScreen(next);
+      setPhase('in');
+    }, ms);
+  }
+
+  return (
+    <div className="w-full max-w-sm space-y-3">
+      <div className="flex flex-wrap items-center gap-1">
+        <ChipButton
+          onClick={() => goTo(screen === 'list' ? 'detail' : 'list')}
+          label={screen === 'list' ? 'Navigate to detail' : 'Back to list'}
         >
-          {label}
-        </li>
-      ))}
-    </ul>
+          {screen === 'list' ? 'Navigate' : 'Back'}
+        </ChipButton>
+        <ChipButton onClick={() => { setSlow(false); setScreen('list'); setPhase('in'); }} label="Replay page transition">
+          Replay
+        </ChipButton>
+        <ChipButton onClick={() => setSlow((v) => !v)} pressed={slow} label="Toggle 900 millisecond contrast">
+          {slow ? '900ms too slow' : '200ms'}
+        </ChipButton>
+      </div>
+      <div className="overflow-hidden rounded-2xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+        <div
+          data-page-screen={screen}
+          data-page-ms={String(ms)}
+          className="p-4"
+          style={{
+            opacity: phase === 'in' ? 1 : 0,
+            transform: phase === 'in' ? 'translateX(0)' : 'translateX(12px)',
+            transition: `opacity ${ms}ms ease-out, transform ${ms}ms ease-out`,
+          }}
+        >
+          {screen === 'list' ? (
+            <div className="space-y-2">
+              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Inbox</p>
+              {['Welcome note', 'Design review', 'Ship checklist'].map((row) => (
+                <button
+                  key={row}
+                  type="button"
+                  onClick={() => goTo('detail')}
+                  className="flex min-h-[44px] w-full items-center rounded-xl border border-zinc-200 px-3 text-left text-sm font-medium text-zinc-700 dark:border-zinc-700 dark:text-zinc-200"
+                >
+                  {row}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Welcome note</p>
+              <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+                A short fade. {slow ? '900ms traps clicks. That is too slow.' : '200ms is enough to feel the scene change.'}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SpringPreview({ reduced }) {
+  const [go, setGo] = useState(false);
+  const replay = useCallback(() => kick(setGo), []);
+  useEffect(() => { replay(); }, [replay]);
+  const ms = reduced ? 0 : 500;
+
+  return (
+    <div className="w-full max-w-lg space-y-4">
+      <ChipButton onClick={replay} label="Replay spring compare">Replay</ChipButton>
+      <div className="relative h-40 rounded-2xl border border-zinc-200 bg-white px-6 dark:border-zinc-700 dark:bg-zinc-900">
+        <div
+          data-target-line=""
+          className="absolute left-4 right-4 top-10 border-t-2 border-dashed border-zinc-400 dark:border-zinc-500"
+        />
+        <p className="absolute left-6 top-2 text-sm font-semibold text-zinc-500">Target</p>
+        <div className="absolute inset-x-6 bottom-4 flex items-end justify-around">
+          {[
+            { id: 'ease-out', label: 'Ease-out', timing: 'ease-out' },
+            { id: 'spring', label: 'Spring', timing: 'cubic-bezier(0.34, 1.56, 0.64, 1)' },
+          ].map((t) => (
+            <div key={t.id} className="flex w-24 flex-col items-center gap-2">
+              <div
+                data-spring={t.id}
+                data-timing={t.timing}
+                className="h-10 w-10 rounded-xl bg-indigo-600"
+                style={{
+                  transform: go ? 'translateY(0)' : 'translateY(72px)',
+                  transitionProperty: 'transform',
+                  transitionDuration: `${ms}ms`,
+                  transitionTimingFunction: t.timing,
+                }}
+              />
+              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">{t.label}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+        Both aim at the dashed line. Ease-out lands. Spring overshoots, then settles.
+      </p>
+    </div>
   );
 }
 
@@ -86,10 +465,78 @@ function HoverPreview({ reduced }) {
   return (
     <button
       type="button"
-      className={`rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm ${reduced ? 'hover:bg-indigo-500' : 'transition duration-150 ease-out hover:-translate-y-0.5 focus-visible:-translate-y-0.5'}`}
+      className={`min-h-[44px] rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm ${reduced ? 'hover:bg-indigo-500' : 'transition duration-150 ease-out hover:-translate-y-0.5 focus-visible:-translate-y-0.5'}`}
     >
       Save draft
     </button>
+  );
+}
+
+function ConfettiPreview({ reduced }) {
+  const [burst, setBurst] = useState(false);
+  const [toast, setToast] = useState(false);
+  const [fly, setFly] = useState(false);
+  const bits = Array.from({ length: 18 }, (_, i) => i);
+
+  useEffect(() => {
+    if (!burst || reduced) {
+      setFly(false);
+      return undefined;
+    }
+    setFly(false);
+    const id = requestAnimationFrame(() => {
+      requestAnimationFrame(() => setFly(true));
+    });
+    return () => cancelAnimationFrame(id);
+  }, [burst, reduced]);
+
+  function complete() {
+    if (burst) return;
+    setBurst(true);
+    setToast(true);
+  }
+
+  function replay() {
+    setBurst(false);
+    setToast(false);
+    setFly(false);
+  }
+
+  return (
+    <div className="relative w-full max-w-sm space-y-3">
+      <div className="flex flex-wrap items-center gap-1">
+        <ChipButton onClick={complete} label="Complete order">Complete order</ChipButton>
+        <ChipButton onClick={replay} label="Replay confetti">Replay</ChipButton>
+      </div>
+      <div className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white px-5 py-8 dark:border-zinc-700 dark:bg-zinc-900">
+        {burst && !reduced && bits.map((i) => (
+          <span
+            key={i}
+            data-confetti-bit=""
+            aria-hidden
+            className="pointer-events-none absolute left-1/2 top-1/2 h-2 w-2 rounded-full bg-indigo-500"
+            style={{
+              transform: fly
+                ? `translate(${Math.cos((i / 18) * Math.PI * 2) * 72}px, ${Math.sin((i / 18) * Math.PI * 2) * 48 - 24}px)`
+                : 'translate(-50%, -50%)',
+              opacity: fly ? 0 : 1,
+              transition: 'transform 700ms ease-out, opacity 700ms ease-out',
+            }}
+          />
+        ))}
+        <p className="relative z-10 text-center text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+          Fires once on a real win. Then it is gone.
+        </p>
+        {toast && (
+          <p
+            data-confetti-toast=""
+            className="relative z-10 mt-3 rounded-lg bg-zinc-900 px-3 py-2 text-center text-sm font-semibold text-white"
+          >
+            Order complete
+          </p>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -118,7 +565,7 @@ function MarqueePreview({ reduced }) {
     return (
       <div className="flex flex-wrap justify-center gap-2">
         {row.map((label) => (
-          <span key={label} className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+          <span key={label} className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-sm font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
             {label}
           </span>
         ))}
@@ -129,10 +576,40 @@ function MarqueePreview({ reduced }) {
     <div className="w-full max-w-md overflow-hidden">
       <div className="vg-marquee-track gap-3">
         {[...row, ...row].map((label, i) => (
-          <span key={`${label}-${i}`} className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+          <span key={`${label}-${i}`} className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-sm font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
             {label}
           </span>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function SharedMorphPreview({ reduced }) {
+  const [open, setOpen] = useState(false);
+  const ms = reduced ? 0 : 220;
+  return (
+    <div className="w-full max-w-sm space-y-3">
+      <ChipButton onClick={() => setOpen((v) => !v)} label={open ? 'Back to list' : 'Open shared card'}>
+        {open ? 'Back' : 'Open card'}
+      </ChipButton>
+      <div className="relative h-48 overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-100 p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div
+          data-shared-morph={open ? 'detail' : 'list'}
+          className="rounded-xl bg-indigo-600 p-4 text-white shadow-sm"
+          style={{
+            width: open ? '100%' : '9rem',
+            height: open ? '10rem' : '5.5rem',
+            transition: `width ${ms}ms ease-out, height ${ms}ms ease-out`,
+          }}
+        >
+          <p className="text-sm font-semibold">Card 12</p>
+          {open && (
+            <p className="mt-2 text-sm leading-relaxed text-indigo-50">
+              Same object. It grew in place. Under 300ms.
+            </p>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -161,46 +638,18 @@ export default function MotionPatternDemo({ demoId }) {
   let body;
   if (demoId === 'particlefield') body = <ParticlePreview reduced={reduced} />;
   else if (demoId === 'easing') body = <EasingPreview reduced={reduced} />;
-  else if (demoId === 'stagger' || demoId === 'scrollreveal') body = <StaggerPreview reduced={reduced} />;
+  else if (demoId === 'stagger') body = <StaggerPreview reduced={reduced} />;
+  else if (demoId === 'scrollreveal') body = <ScrollRevealPreview reduced={reduced} />;
   else if (demoId === 'hovermicro') body = <HoverPreview reduced={reduced} />;
   else if (demoId === 'countup') body = <CountPreview reduced={reduced} />;
   else if (demoId === 'marquee') body = <MarqueePreview reduced={reduced} />;
-  else if (demoId === 'reducedmotion') {
-    body = (
-      <p className="max-w-sm text-center text-base leading-relaxed text-zinc-600 dark:text-zinc-300">
-        Keep the information. Drop the spectacle. This preview stays still when the OS asks for reduced motion.
-      </p>
-    );
-  } else if (demoId === 'spring') {
-    body = (
-      <div className={`flex h-16 w-16 items-center justify-center rounded-2xl bg-lime-500 text-lg font-black text-white ${reduced ? '' : 'transition-transform duration-500 ease-out hover:scale-110'}`}>
-        OK
-      </div>
-    );
-  } else if (demoId === 'confetti') {
-    body = (
-      <p className="max-w-sm text-center text-base leading-relaxed text-zinc-600 dark:text-zinc-300">
-        A one-shot burst on a real win. Then it is gone. Pair it with a toast.
-      </p>
-    );
-  } else if (demoId === 'parallax') {
-    body = (
-      <div className="relative h-40 w-full max-w-sm overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900">
-        <div className="absolute inset-x-6 top-8 h-16 rounded-xl bg-zinc-300/80 dark:bg-zinc-700/80" />
-        <div className="absolute inset-x-10 top-16 rounded-xl border border-zinc-200 bg-white p-4 text-sm font-semibold text-zinc-800 shadow-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100">
-          Foreground stays readable
-        </div>
-      </div>
-    );
-  } else if (demoId === 'pagetransition' || demoId === 'sharedmorph') {
-    body = (
-      <div className="flex items-center gap-3">
-        <div className="h-20 w-20 rounded-xl bg-indigo-600" />
-        <span className="text-zinc-400">to</span>
-        <div className="h-28 w-40 rounded-2xl bg-indigo-600/80" />
-      </div>
-    );
-  } else {
+  else if (demoId === 'reducedmotion') body = <ReducedMotionPreview reduced={reduced} />;
+  else if (demoId === 'spring') body = <SpringPreview reduced={reduced} />;
+  else if (demoId === 'confetti') body = <ConfettiPreview reduced={reduced} />;
+  else if (demoId === 'parallax') body = <ParallaxPreview reduced={reduced} />;
+  else if (demoId === 'pagetransition') body = <PageTransitionPreview reduced={reduced} />;
+  else if (demoId === 'sharedmorph') body = <SharedMorphPreview reduced={reduced} />;
+  else {
     body = (
       <p className="max-w-sm text-center text-base leading-relaxed text-zinc-600 dark:text-zinc-300">
         Definition and prompt are ready. Motion stays optional.
@@ -208,5 +657,8 @@ export default function MotionPatternDemo({ demoId }) {
     );
   }
 
-  return <Frame title={title}>{body}</Frame>;
+  const fill = demoId === 'parallax' || demoId === 'scrollreveal';
+  return <Frame title={title} fill={fill}>{body}</Frame>;
 }
+
+export { EASING_TRAVELERS };

--- a/src/test/MotionPatternDemo.test.jsx
+++ b/src/test/MotionPatternDemo.test.jsx
@@ -1,0 +1,142 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MotionPatternDemo, { EASING_TRAVELERS } from '../components/demos/MotionPatternDemo';
+
+function mockMotion(reduce) {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: reduce && String(query).includes('prefers-reduced-motion'),
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  mockMotion(false);
+});
+
+describe('#24 easing travelers teach real curves', () => {
+  it('renders three travelers with distinct CSS timings and a Replay control', () => {
+    render(<MotionPatternDemo demoId="easing" />);
+    const travelers = document.querySelectorAll('[data-easing]');
+    expect(travelers).toHaveLength(3);
+    const timings = [...travelers].map((el) => el.getAttribute('data-timing'));
+    expect(timings).toEqual(['ease-out', 'ease-in', 'linear']);
+    expect(new Set(timings).size).toBe(3);
+    expect(EASING_TRAVELERS.map((t) => t.timing)).toEqual(['ease-out', 'ease-in', 'linear']);
+    travelers.forEach((el) => {
+      expect(el.className).not.toMatch(/vg-bob/);
+      expect(el.style.transitionTimingFunction).toBe(el.getAttribute('data-timing'));
+    });
+    expect(screen.getByRole('button', { name: /Replay easing compare/i })).toBeInTheDocument();
+    expect(screen.getByText(/Ease-out gets there fast then settles/i)).toBeInTheDocument();
+  });
+
+  it('uses 0ms duration when the OS asks for reduced motion', () => {
+    mockMotion(true);
+    render(<MotionPatternDemo demoId="easing" />);
+    document.querySelectorAll('[data-easing]').forEach((el) => {
+      expect(el.getAttribute('data-duration-ms')).toBe('0');
+    });
+  });
+});
+
+describe('#25 motion pattern previews are real', () => {
+  it('Particle Field has page copy and a toggle', () => {
+    render(<MotionPatternDemo demoId="particlefield" />);
+    expect(screen.getByText('The page still reads')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-particle-dot]').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /Hide particles/i })).toBeInTheDocument();
+  });
+
+  it('Parallax exposes three labeled speeds in a scroll viewport', () => {
+    render(<MotionPatternDemo demoId="parallax" />);
+    expect(document.querySelector('[data-parallax-scroller]')).toBeTruthy();
+    expect(document.querySelector('[data-parallax-speed="0.2"]')).toBeTruthy();
+    expect(document.querySelector('[data-parallax-speed="0.6"]')).toBeTruthy();
+    expect(document.querySelector('[data-parallax-speed="1"]')).toBeTruthy();
+  });
+
+  it('Stagger prints delays and can switch to all-at-once', async () => {
+    const user = userEvent.setup();
+    render(<MotionPatternDemo demoId="stagger" />);
+    const rows = document.querySelectorAll('[data-stagger-row]');
+    expect(rows).toHaveLength(3);
+    expect([...rows].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '50ms', '100ms']);
+    await user.click(screen.getByRole('button', { name: /Play all at once/i }));
+    expect([...document.querySelectorAll('[data-stagger-row]')].every((r) => r.getAttribute('data-stagger-delay') === '0ms')).toBe(true);
+    expect(screen.getByRole('button', { name: /Replay stagger/i })).toBeInTheDocument();
+  });
+
+  it('Scroll Reveal is its own scroll panel with Reset', () => {
+    render(<MotionPatternDemo demoId="scrollreveal" />);
+    expect(document.querySelector('[data-scroll-reveal]')).toBeTruthy();
+    expect(screen.getByText(/Cards rise as they cross this line/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Reset scroll reveal/i })).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-reveal-card]').length).toBe(4);
+  });
+
+  it('Reduced Motion shows motion-on and reduced panels', () => {
+    render(<MotionPatternDemo demoId="reducedmotion" />);
+    expect(document.querySelector('[data-motion-panel="motion"]')).toBeTruthy();
+    expect(document.querySelector('[data-motion-panel="reduced"]')).toBeTruthy();
+    expect(screen.getByText(/Do not just shorten the same loop/i)).toBeInTheDocument();
+  });
+
+  it('Page Transition has List to Detail with Navigate and Replay', async () => {
+    const user = userEvent.setup();
+    render(<MotionPatternDemo demoId="pagetransition" />);
+    expect(document.querySelector('[data-page-screen="list"]')).toBeTruthy();
+    expect(document.querySelector('[data-page-ms]').getAttribute('data-page-ms')).toBe('200');
+    await user.click(screen.getByRole('button', { name: /Navigate to detail/i }));
+    expect(await screen.findByText(/200ms is enough/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Replay page transition/i })).toBeInTheDocument();
+  });
+
+  it('Spring compares ease-out and spring against a target line', () => {
+    render(<MotionPatternDemo demoId="spring" />);
+    expect(document.querySelector('[data-target-line]')).toBeTruthy();
+    const ease = document.querySelector('[data-spring="ease-out"]');
+    const spring = document.querySelector('[data-spring="spring"]');
+    expect(ease.getAttribute('data-timing')).toBe('ease-out');
+    expect(spring.getAttribute('data-timing')).toMatch(/cubic-bezier/);
+    expect(ease.getAttribute('data-timing')).not.toBe(spring.getAttribute('data-timing'));
+    expect(screen.getByRole('button', { name: /Replay spring compare/i })).toBeInTheDocument();
+  });
+
+  it('Confetti fires once on Complete order and shows a toast', async () => {
+    const user = userEvent.setup();
+    render(<MotionPatternDemo demoId="confetti" />);
+    expect(screen.queryByText('Order complete')).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'Complete order' }));
+    expect(screen.getByText('Order complete')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-confetti-bit]').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Fires once on a real win/i)).toBeInTheDocument();
+  });
+
+  it('Hover Micro still lifts on hover', () => {
+    render(<MotionPatternDemo demoId="hovermicro" />);
+    const btn = screen.getByRole('button', { name: 'Save draft' });
+    expect(btn.className).toMatch(/duration-150/);
+    expect(btn.className).toMatch(/ease-out/);
+  });
+
+  it('Reduced Motion OS path keeps the reduced toast instant', () => {
+    mockMotion(true);
+    render(<MotionPatternDemo demoId="reducedmotion" />);
+    expect(screen.getByText(/Your OS asked for reduced motion/i)).toBeInTheDocument();
+    const motion = document.querySelector('[data-motion-panel="motion"]');
+    expect(motion.style.transition).toBe('none');
+  });
+
+  it('user-facing demo copy has no em dashes or native title=', () => {
+    ['easing', 'particlefield', 'parallax', 'stagger', 'scrollreveal', 'reducedmotion', 'pagetransition', 'spring', 'confetti'].forEach((id) => {
+      const { unmount, container } = render(<MotionPatternDemo demoId={id} />);
+      expect(container.textContent, id).not.toMatch(/\u2014/);
+      expect(container.querySelector('[title]'), id).toBeNull();
+      unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **#24 Easing:** Three labeled travelers on identical tracks. One Replay starts them together. Real `transition-timing-function` values: `ease-out`, `ease-in`, `linear`. Optional slow-mo (1200ms). Beginner line: same distance, same 300ms, ease-out gets there fast then settles, ease-in creeps then rushes. Does not reuse `vg-bob-float`. CLAUDE.md: previews must teach at a glance. DESIGN.md: live demos readable at a glance. glossaryMotion.js: Ease-out arrives. Ease-in leaves. Linear almost never feels right.
- **#25 Pattern demos:** Each listed preview now demonstrates its rule (not a named stub). Hover Micro left alone (already real). Design Language motion topic copy untouched. Welcome ParticleField / hero reduced-motion path / firebase / lockfile untouched.

### What each demo does
- **Particle Field:** Headline + body over CSS dots. Toggle particles. Page still reads with dots off. Pulse only, not vg-bob. No welcome ParticleField import.
- **Parallax:** Scrollable mini-viewport. Three labeled speeds 0.2 / 0.6 / 1.0 that lag differently.
- **Stagger:** All-at-once vs 50ms stagger. Replay. Delays printed on rows.
- **Scroll Reveal:** Own scroll panel. Cards rise as they cross a dashed viewport line. Reset. Not a Stagger clone.
- **Reduced Motion:** Two panels, same toast. Motion on slides in. Reduced is instant. OS `prefers-reduced-motion` keeps both still.
- **Page Transition:** Inbox list to detail. Navigate + Replay. 200ms ease-out, optional 900ms too-slow contrast.
- **Spring:** Ease-out vs spring side by side. Replay. Dashed target line so overshoot is visible.
- **Confetti:** Complete order fires a one-shot burst + Order complete toast. Replay. Copy: fires once on a real win.

## Test plan
- [ ] `/glossary/easing`: three travelers, distinct curves, Replay, optional Slow-mo
- [ ] Particle Field, Parallax, Stagger, Scroll Reveal, Reduced Motion, Page Transition, Spring, Confetti on `/glossary/...`
- [ ] OS reduced motion: easing snaps, both reduced-motion toasts instant, confetti toast only
- [ ] Hover Micro still lifts
- [ ] `npx vitest run src/test/MotionPatternDemo.test.jsx`