### PR TITLE
fix: glossary chrome #29-32 and obvious stagger/confetti

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -577,7 +577,7 @@ export default function App() {
                         onClick={toggleLearnMode}
                         aria-pressed={learnMode}
                         aria-label={learnMode ? 'Exit Learn Mode' : 'Turn on Learn Mode (quiz each component)'}
-                        className="group relative ml-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent"
+                        className="group relative ml-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] h-11 shrink-0 bg-transparent"
                       >
                         <span
                           className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs lg:text-sm font-semibold border transition-colors ${

--- a/src/components/demos/MotionPatternDemo.jsx
+++ b/src/components/demos/MotionPatternDemo.jsx
@@ -180,9 +180,9 @@ function ParallaxPreview({ reduced }) {
 
 function StaggerPreview({ reduced }) {
   const items = [
-    { label: 'Inbox', delay: 0 },
-    { label: 'Drafts', delay: 50 },
-    { label: 'Sent', delay: 100 },
+    { label: 'Inbox', delay: 0, bar: 'bg-indigo-600', well: 'bg-white dark:bg-zinc-900' },
+    { label: 'Drafts', delay: 50, bar: 'bg-indigo-500', well: 'bg-indigo-50 dark:bg-indigo-950/60' },
+    { label: 'Sent', delay: 100, bar: 'bg-sky-500', well: 'bg-sky-50 dark:bg-sky-950/40' },
   ];
   const [mode, setMode] = useState('stagger');
   const [go, setGo] = useState(false);
@@ -190,7 +190,7 @@ function StaggerPreview({ reduced }) {
   useEffect(() => { replay(); }, [replay, mode]);
 
   return (
-    <div className="w-full max-w-sm space-y-3">
+    <div className="w-full max-w-lg space-y-4">
       <div className="flex flex-wrap items-center gap-1">
         <ChipButton onClick={() => setMode('together')} pressed={mode === 'together'} label="Play all at once">
           All at once
@@ -198,28 +198,21 @@ function StaggerPreview({ reduced }) {
         <ChipButton onClick={() => setMode('stagger')} pressed={mode === 'stagger'} label="Play 50 millisecond stagger">
           50ms stagger
         </ChipButton>
-        <ChipButton onClick={replay} label="Replay stagger">Replay</ChipButton>
+        <button type="button" onClick={replay} aria-label="Replay stagger" className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-indigo-600 px-4 text-sm font-semibold text-white hover:bg-indigo-500">Replay</button>
       </div>
-      <ul className="space-y-2">
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+        {mode === 'together' ? 'All at once: Inbox, Drafts, and Sent rise together. No waiting.' : '50ms stagger: Inbox moves first. Drafts waits 50ms. Sent waits 100ms.'}
+      </p>
+      <ul data-stagger-mode={mode} className="space-y-3">
         {items.map((row) => {
           const delay = mode === 'stagger' && !reduced ? row.delay : 0;
           return (
-            <li
-              key={row.label}
-              data-stagger-row={row.label}
-              data-stagger-delay={`${delay}ms`}
-              className="flex items-center justify-between rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm font-semibold text-zinc-800 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
-              style={{
-                opacity: go ? 1 : 0,
-                transform: go ? 'translateY(0)' : 'translateY(12px)',
-                transitionProperty: 'opacity, transform',
-                transitionDuration: reduced ? '0ms' : '300ms',
-                transitionTimingFunction: 'ease-out',
-                transitionDelay: `${delay}ms`,
-              }}
-            >
-              <span>{row.label}</span>
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{delay}ms</span>
+            <li key={row.label} data-stagger-row={row.label} data-stagger-delay={`${delay}ms`} className={`flex items-center justify-between overflow-hidden rounded-xl border border-zinc-200 ${row.well} text-base font-semibold text-zinc-900 shadow-sm dark:border-zinc-700 dark:text-zinc-50`} style={{ opacity: go ? 1 : 0, transform: go ? 'translateX(0)' : 'translateX(-36px)', transitionProperty: 'opacity, transform', transitionDuration: reduced ? '0ms' : '520ms', transitionTimingFunction: 'ease-out', transitionDelay: `${delay}ms` }}>
+              <span className="inline-flex min-h-[52px] items-center gap-3 px-4">
+                <span className={`h-8 w-1.5 rounded-full ${row.bar}`} aria-hidden />
+                {row.label}
+              </span>
+              <span className="mr-3 rounded-full bg-zinc-900 px-2.5 py-1 text-sm font-bold tabular-nums text-white dark:bg-white dark:text-zinc-900">{delay}ms</span>
             </li>
           );
         })}
@@ -476,7 +469,8 @@ function ConfettiPreview({ reduced }) {
   const [burst, setBurst] = useState(false);
   const [toast, setToast] = useState(false);
   const [fly, setFly] = useState(false);
-  const bits = Array.from({ length: 18 }, (_, i) => i);
+  const colors = ['bg-indigo-500', 'bg-amber-400', 'bg-emerald-400', 'bg-rose-500', 'bg-sky-400', 'bg-violet-500'];
+  const bits = Array.from({ length: 36 }, (_, i) => i);
 
   useEffect(() => {
     if (!burst || reduced) {
@@ -503,35 +497,39 @@ function ConfettiPreview({ reduced }) {
   }
 
   return (
-    <div className="relative w-full max-w-sm space-y-3">
+    <div className="relative w-full max-w-lg space-y-3">
       <div className="flex flex-wrap items-center gap-1">
-        <ChipButton onClick={complete} label="Complete order">Complete order</ChipButton>
-        <ChipButton onClick={replay} label="Replay confetti">Replay</ChipButton>
+        <button type="button" onClick={complete} aria-label="Complete order" className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-indigo-600 px-5 text-sm font-semibold text-white hover:bg-indigo-500">Complete order</button>
+        <button type="button" onClick={replay} aria-label="Replay confetti" className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-zinc-200 bg-white px-4 text-sm font-semibold text-zinc-800 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100">Replay</button>
       </div>
-      <div className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white px-5 py-8 dark:border-zinc-700 dark:bg-zinc-900">
-        {burst && !reduced && bits.map((i) => (
-          <span
-            key={i}
-            data-confetti-bit=""
-            aria-hidden
-            className="pointer-events-none absolute left-1/2 top-1/2 h-2 w-2 rounded-full bg-indigo-500"
-            style={{
-              transform: fly
-                ? `translate(${Math.cos((i / 18) * Math.PI * 2) * 72}px, ${Math.sin((i / 18) * Math.PI * 2) * 48 - 24}px)`
-                : 'translate(-50%, -50%)',
-              opacity: fly ? 0 : 1,
-              transition: 'transform 700ms ease-out, opacity 700ms ease-out',
-            }}
-          />
-        ))}
-        <p className="relative z-10 text-center text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+        Tap Complete order for a bright burst. Replay to arm it again.
+      </p>
+      <div className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 px-5 py-12 dark:border-zinc-700" data-confetti-stage="">
+        {burst && !reduced && bits.map((i) => {
+          const angle = (i / 36) * Math.PI * 2;
+          const dist = 88 + (i % 5) * 14;
+          const wide = i % 3 === 1;
+          return (
+            <span
+              key={i}
+              data-confetti-bit=""
+              data-confetti-color={colors[i % colors.length]}
+              aria-hidden
+              className={`pointer-events-none absolute left-1/2 top-1/2 ${wide ? 'h-3 w-5' : 'h-3.5 w-3.5'} ${i % 2 === 0 ? 'rounded-full' : 'rounded-sm'} ${colors[i % colors.length]}`}
+              style={{
+                transform: fly ? `translate(${Math.cos(angle) * dist}px, ${Math.sin(angle) * dist - 28}px) rotate(${i * 24}deg)` : 'translate(-50%, -50%)',
+                opacity: fly ? 0 : 1,
+                transition: 'transform 900ms ease-out, opacity 900ms ease-out',
+              }}
+            />
+          );
+        })}
+        <p className="relative z-10 text-center text-base font-semibold text-white">
           Fires once on a real win. Then it is gone.
         </p>
         {toast && (
-          <p
-            data-confetti-toast=""
-            className="relative z-10 mt-3 rounded-lg bg-zinc-900 px-3 py-2 text-center text-sm font-semibold text-white"
-          >
+          <p data-confetti-toast="" className="relative z-10 mt-4 rounded-lg bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white">
             Order complete
           </p>
         )}

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -24,7 +24,7 @@ export default function Footer() {
           href={CHANGELOG_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 hover:text-zinc-900 dark:hover:text-white transition-colors"
+          className="inline-flex items-center gap-2 min-h-[44px] hover:text-zinc-900 dark:hover:text-white transition-colors"
         >
           <FileText size={18} />
           Changelog
@@ -33,7 +33,7 @@ export default function Footer() {
           href={REPO_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 hover:text-zinc-900 dark:hover:text-white transition-colors"
+          className="inline-flex items-center gap-2 min-h-[44px] hover:text-zinc-900 dark:hover:text-white transition-colors"
         >
           <Github size={18} />
           GitHub

--- a/src/components/learn/ScoreBreakdownModal.jsx
+++ b/src/components/learn/ScoreBreakdownModal.jsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { POINTS, LEVELS } from '../../lib/scoring';
 import ShareAchievement from './ShareAchievement';
+import HoverTip from '../ui/HoverTip';
 
 /**
  * Modal that shows where the learner's VibeScore came from. Splits the total
@@ -59,7 +60,7 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onO
                 type="button"
                 onClick={onOpenProof}
                 data-tour="class-proof"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold bg-indigo-500/10 hover:bg-indigo-500/20 text-indigo-600 dark:text-indigo-300 border border-indigo-500/20 transition-colors"
+                className="inline-flex items-center justify-center gap-1.5 min-h-[44px] px-3 py-1.5 rounded-lg text-sm font-semibold bg-indigo-500/10 hover:bg-indigo-500/20 text-indigo-600 dark:text-indigo-300 border border-indigo-500/20 transition-colors"
               >
                 <ShieldCheck size={14} />
                 Class proof
@@ -81,7 +82,7 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onO
             )}
             <button
               onClick={onClose}
-              className="p-2 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+              className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
               aria-label="Close score breakdown"
             >
               <X size={20} />
@@ -117,16 +118,20 @@ export default function ScoreBreakdownModal({ isOpen, onClose, score, level, onO
                 return (
                   <span
                     key={l.id}
-                    className={`px-2.5 py-1 rounded-full text-xs font-bold border transition-colors ${
+                    tabIndex={0}
+                    className="group relative inline-flex items-center justify-center min-h-[44px] min-w-[44px]"
+                    aria-label={`${l.label}. ${l.blurb}`}
+                  >
+                    <span className={`px-2.5 py-1 rounded-full text-xs font-bold border transition-colors ${
                       isCurrent
                         ? 'bg-amber-500 text-white border-amber-500'
                         : reached
                           ? 'bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700/40'
                           : 'bg-transparent text-zinc-400 dark:text-zinc-500 border-zinc-200 dark:border-zinc-700'
-                    }`}
-                    title={l.blurb}
-                  >
-                    {l.label}
+                    }`}>
+                      {l.label}
+                    </span>
+                    <HoverTip text={l.blurb} />
                   </span>
                 );
               })}

--- a/src/components/learn/ShareAchievement.jsx
+++ b/src/components/learn/ShareAchievement.jsx
@@ -139,7 +139,7 @@ export default function ShareAchievement({
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={popoverId}
-        className={`inline-flex items-center gap-2 rounded-lg font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500/50 ${triggerSize} ${triggerStyle}`}
+        className={`inline-flex items-center justify-center gap-2 min-h-[44px] rounded-lg font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500/50 ${triggerSize} ${triggerStyle}`}
       >
         <Share2 size={size === 'sm' ? 14 : 16} />
         {label}

--- a/src/components/ui/PromptBuilder.jsx
+++ b/src/components/ui/PromptBuilder.jsx
@@ -225,7 +225,7 @@ export default function PromptBuilder({ data, activeOptions, onOptionToggle, cat
         <button
           type="button"
           onClick={handleCopy}
-          className="group absolute top-1 right-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent text-zinc-500 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100"
+          className="group absolute top-1 right-1 inline-flex items-center justify-center min-h-[44px] min-w-[44px] bg-transparent text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
           aria-label="Copy to clipboard (markdown)"
         >
           <span className="p-2 rounded-lg bg-zinc-100 dark:bg-zinc-800 group-hover:bg-zinc-200 dark:group-hover:bg-zinc-700">

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -206,3 +206,22 @@ describe('shareable topic URLs', () => {
     expect(screen.getByTestId('top-nav')).toBeInTheDocument();
   });
 });
+
+describe('#29 glossary Quiz me uses a 44px hit box', () => {
+  it('Learn Mode control on /glossary/modal is 44px with compact paint', async () => {
+    localStorage.setItem('vg-visited', '1');
+    window.history.replaceState(null, '', '/glossary/modal');
+    await act(async () => {
+      render(<App />);
+    });
+    const btn = screen.getByRole('button', { name: /Turn on Learn Mode \(quiz each component\)/i });
+    expect(btn.className).toMatch(/min-h-\[44px\]/);
+    expect(btn.className).toMatch(/h-11/);
+    expect(btn.className).not.toMatch(/bg-indigo-600/);
+    const paint = btn.querySelector('span.rounded-full');
+    expect(paint).toBeTruthy();
+    expect(paint.className).toMatch(/py-1/);
+    expect(paint.className).not.toMatch(/min-h-\[44px\]/);
+    expect(paint.textContent).toMatch(/Quiz me/);
+  });
+});

--- a/src/test/MotionPatternDemo.test.jsx
+++ b/src/test/MotionPatternDemo.test.jsx
@@ -65,6 +65,9 @@ describe('#25 motion pattern previews are real', () => {
     const rows = document.querySelectorAll('[data-stagger-row]');
     expect(rows).toHaveLength(3);
     expect([...rows].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '50ms', '100ms']);
+    expect(new Set([...rows].map((r) => r.getAttribute('data-stagger-delay'))).size).toBe(3);
+    expect(document.querySelector('[data-stagger-mode="stagger"]')).toBeTruthy();
+    expect(screen.getByText(/Inbox moves first/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Play all at once/i }));
     expect([...document.querySelectorAll('[data-stagger-row]')].every((r) => r.getAttribute('data-stagger-delay') === '0ms')).toBe(true);
     expect(screen.getByRole('button', { name: /Replay stagger/i })).toBeInTheDocument();
@@ -112,7 +115,10 @@ describe('#25 motion pattern previews are real', () => {
     expect(screen.queryByText('Order complete')).toBeNull();
     await user.click(screen.getByRole('button', { name: 'Complete order' }));
     expect(screen.getByText('Order complete')).toBeInTheDocument();
-    expect(document.querySelectorAll('[data-confetti-bit]').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('[data-confetti-bit]').length).toBeGreaterThanOrEqual(24);
+    const burstColors = new Set([...document.querySelectorAll('[data-confetti-color]')].map((el) => el.getAttribute('data-confetti-color')));
+    expect(burstColors.size).toBeGreaterThanOrEqual(4);
+    expect(screen.getByRole('button', { name: /Replay confetti/i })).toBeInTheDocument();
     expect(screen.getByText(/Fires once on a real win/i)).toBeInTheDocument();
   });
 

--- a/src/test/chromeLeftovers.test.jsx
+++ b/src/test/chromeLeftovers.test.jsx
@@ -3,9 +3,14 @@ import TopicTierBadge from '../components/learn/TopicTierBadge';
 import TalkToAiCard from '../components/learn/TalkToAiCard';
 import PromptBuilder from '../components/ui/PromptBuilder';
 import ScoreBreakdownModal from '../components/learn/ScoreBreakdownModal';
+import Footer from '../components/layout/Footer';
 import BuildTopicView from '../components/learn/BuildTopicView';
 import { AUTH_ERROR_COPY, AUTH_ERROR_FALLBACK } from '../lib/authErrors';
 import { levelFor } from '../lib/scoring';
+
+vi.mock('../hooks/useCategories', () => ({
+  useCategories: () => [{ id: 'overlays', items: [{ id: 'modal' }] }],
+}));
 
 const topic = {
   id: 'particle-field',
@@ -66,6 +71,9 @@ describe('#21 Quiz me and Copy keep compact paint and a 44px hit box', () => {
     const btn = screen.getByRole('button', { name: 'Copy to clipboard (markdown)' });
     expect(btn).not.toHaveAttribute('title');
     expect(btn.className).toMatch(/min-h-\[44px\]/);
+    expect(btn.className).toMatch(/min-w-\[44px\]/);
+    expect(btn.className).not.toMatch(/opacity-0/);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Copy to clipboard');
   });
 });
 
@@ -105,5 +113,52 @@ describe('#23 Visited badge uses HoverTip, not title=', () => {
     expect(badge).not.toHaveAttribute('title');
     expect(badge.getAttribute('aria-label')).toMatch(/Copy a prompt to reach Used/);
     expect(screen.getByRole('tooltip')).toHaveTextContent('Copy a prompt to reach Used.');
+  });
+});
+
+describe('#32 VibeScore modal hit boxes and no title= on level chips', () => {
+  const score = {
+    total: 12,
+    glossary: { total: 12, visited: 12, used: 0, passed: 0, mastered: 0, retained: 0, pathBonus: 0 },
+    build: { total: 0, visited: 0, used: 0, passed: 0, mastered: 0, retained: 0, pathBonus: 0 },
+  };
+
+  it('Class proof, Share score, and Close are 44px', () => {
+    render(
+      <ScoreBreakdownModal
+        isOpen
+        onClose={() => {}}
+        onOpenProof={() => {}}
+        score={score}
+        level={levelFor(12)}
+      />
+    );
+    expect(screen.getByRole('button', { name: /Class proof/i }).className).toMatch(/min-h-\[44px\]/);
+    expect(screen.getByRole('button', { name: /Share score/i }).className).toMatch(/min-h-\[44px\]/);
+    expect(screen.getByRole('button', { name: /Close score breakdown/i }).className).toMatch(/min-h-\[44px\]/);
+  });
+
+  it('level chips use HoverTip and aria-label, not title=', () => {
+    const { container } = render(
+      <ScoreBreakdownModal
+        isOpen
+        onClose={() => {}}
+        score={score}
+        level={levelFor(12)}
+      />
+    );
+    expect(container.querySelector('[title]')).toBeNull();
+    const lurker = screen.getByLabelText(/Lurker/);
+    expect(lurker).not.toHaveAttribute('title');
+    expect(lurker.getAttribute('aria-label')).toMatch(/Just looking around/);
+    expect(lurker.className).toMatch(/min-h-\[44px\]/);
+  });
+});
+
+describe('#32 footer Changelog and GitHub are 44px', () => {
+  it('Changelog and GitHub links use a 44px hit box', () => {
+    render(<Footer />);
+    expect(screen.getByRole('link', { name: /Changelog/i }).className).toMatch(/min-h-\[44px\]/);
+    expect(screen.getByRole('link', { name: /GitHub/i }).className).toMatch(/min-h-\[44px\]/);
   });
 });


### PR DESCRIPTION
## Summary
- **#29 Glossary Quiz me:** Same 44px hit box as Build literacy (`min-h-[44px] h-11`), compact `py-1` chip. Paint stays a small pill. DESIGN.md Buttons / Accessibility: 44px is the hit box, visual may stay 32 to 40px. CLAUDE.md touch targets ≥44px.
- **#30 Glossary Visited:** Already HoverTip + aria-label (no `title=`). Tests lock that. DESIGN.md Icon actions and tips: in-app tip, not native `title=`.
- **#31 Spec Generator Copy:** 44 hit, HoverTip + `aria-label`, no `title=`. Always visible (no hover-only `opacity-0`). Compact icon, not a fat labeled pill.
- **#32 VibeScore modal:** Class proof, Share score, and Close are 44px. Level chips use HoverTip + aria-label (blurbs like "Just looking around. Welcome."). Footer Changelog and GitHub are 44px. Compact paint.
- **Stagger / Confetti:** Larger contrast, color bars, 36px slide, printed delays, indigo Replay. Confetti is a 36-bit multi-color burst on Complete order plus toast. Replay obvious. Passing demos (easing, parallax, scroll reveal, reduced motion, page transition, spring, hover micro, particle field preview) untouched.

## Test plan
- [ ] `/glossary/modal` Quiz me measures ≥44px. Chip paint stays compact.
- [ ] VISITED badge: no native `title=`. Hover/focus shows HoverTip.
- [ ] Spec Generator Copy is visible without hovering the code well. 44 hit. No `title=`.
- [ ] Open VibeScore: Class proof, Share score, Close ≥44. Level chips have no `title=`. Footer Changelog / GitHub ≥44.
- [ ] `/glossary/stagger`: All-at-once vs 50ms stagger is obvious. Rows have distinct delays. Replay works.
- [ ] `/glossary/confetti`: Complete order fires a bright burst + Order complete toast. Replay works.
- [ ] `npx vitest run src/test/App.test.jsx src/test/chromeLeftovers.test.jsx src/test/MotionPatternDemo.test.jsx`

Fixes #29
Fixes #30
Fixes #31
Fixes #32