### PR TITLE
fix: glanceable stagger/confetti and no stale-bundle white screen

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,9 +9,53 @@
       "**/.*",
       "**/node_modules/**"
     ],
-    "rewrites": [
+    "headers": [
       {
         "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
+    ],
+    "rewrites": [
+      {
+        "source": "/",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/glossary",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/glossary/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/build",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/build/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/components",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/components/**",
         "destination": "/index.html"
       }
     ]

--- a/index.html
+++ b/index.html
@@ -35,5 +35,25 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      (function () {
+        var shown = false;
+        function showRefresh() {
+          if (shown) return;
+          var root = document.getElementById('root');
+          if (root && root.childElementCount) return;
+          shown = true;
+          var wrap = document.createElement('div');
+          wrap.setAttribute('data-boot-fallback', '');
+          wrap.style.cssText = 'font-family:system-ui,sans-serif;min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:32px;background:#09090b;color:#f4f4f5;text-align:center';
+          wrap.innerHTML = '<p style="font-size:16px;max-width:28rem;line-height:1.5">This page needs a refresh to load the latest version.</p><button type="button" style="min-height:44px;padding:0 20px;border:0;border-radius:12px;background:#4f46e5;color:#fff;font-size:14px;font-weight:600;cursor:pointer">Refresh</button>';
+          wrap.querySelector('button').onclick = function () { location.reload(); };
+          document.body.appendChild(wrap);
+        }
+        var mod = document.querySelector('script[type="module"]');
+        if (mod) mod.addEventListener('error', showRefresh);
+        window.setTimeout(showRefresh, 6000);
+      })();
+    </script>
   </body>
 </html>

--- a/src/components/demos/MotionPatternDemo.jsx
+++ b/src/components/demos/MotionPatternDemo.jsx
@@ -9,7 +9,7 @@ function prefersReducedMotion() {
   }
 }
 
-function Frame({ title, children, fill = false }) {
+function Frame({ title, children, fill = false, clip = true }) {
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-zinc-50/80 dark:bg-zinc-950/40">
       <div className="shrink-0 border-b border-zinc-200/80 px-4 pb-3 pt-4 dark:border-zinc-800/80 sm:px-6">
@@ -18,7 +18,7 @@ function Frame({ title, children, fill = false }) {
         </p>
         <p className="truncate text-sm font-semibold text-zinc-800 dark:text-zinc-100">{title}</p>
       </div>
-      <div className={`flex min-h-0 flex-1 overflow-auto p-4 sm:p-6 ${fill ? 'items-stretch' : 'items-center justify-center'}`}>
+      <div className={`flex min-h-0 flex-1 ${clip ? 'overflow-auto' : 'overflow-visible'} p-4 sm:p-6 ${fill ? 'items-stretch' : 'items-center justify-center'}`}>
         {children}
       </div>
     </div>
@@ -52,6 +52,19 @@ function kick(setGo) {
     requestAnimationFrame(() => setGo(true));
   });
 }
+
+// Glanceable motion constants. Tess #34/#35: travel and pieces must be
+// measurable in px, not a 2-4px fade stub. DESIGN.md: readable at a glance.
+export const STAGGER_TRAVEL_PX = 80;
+export const STAGGER_DURATION_MS = 900;
+export const STAGGER_STEP_MS = 50;
+
+export const CONFETTI_COUNT = 28;
+export const CONFETTI_SIZE_PX = 22;
+export const CONFETTI_SPREAD_PX = 200;
+export const CONFETTI_FLY_MS = 2000;
+export const CONFETTI_FADE_DELAY_MS = 1600;
+export const CONFETTI_FADE_MS = 700;
 
 const EASING_TRAVELERS = [
   { id: 'ease-out', label: 'Ease-out', timing: 'ease-out' },
@@ -181,13 +194,16 @@ function ParallaxPreview({ reduced }) {
 function StaggerPreview({ reduced }) {
   const items = [
     { label: 'Inbox', delay: 0, bar: 'bg-indigo-600', well: 'bg-white dark:bg-zinc-900' },
-    { label: 'Drafts', delay: 50, bar: 'bg-indigo-500', well: 'bg-indigo-50 dark:bg-indigo-950/60' },
-    { label: 'Sent', delay: 100, bar: 'bg-sky-500', well: 'bg-sky-50 dark:bg-sky-950/40' },
+    { label: 'Drafts', delay: STAGGER_STEP_MS, bar: 'bg-indigo-500', well: 'bg-indigo-50 dark:bg-indigo-950/60' },
+    { label: 'Sent', delay: STAGGER_STEP_MS * 2, bar: 'bg-sky-500', well: 'bg-sky-50 dark:bg-sky-950/40' },
   ];
   const [mode, setMode] = useState('stagger');
   const [go, setGo] = useState(false);
   const replay = useCallback(() => kick(setGo), []);
   useEffect(() => { replay(); }, [replay, mode]);
+
+  const fromX = `${STAGGER_TRAVEL_PX}px`;
+  const toX = '0px';
 
   return (
     <div className="w-full max-w-lg space-y-4">
@@ -201,18 +217,43 @@ function StaggerPreview({ reduced }) {
         <button type="button" onClick={replay} aria-label="Replay stagger" className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-indigo-600 px-4 text-sm font-semibold text-white hover:bg-indigo-500">Replay</button>
       </div>
       <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
-        {mode === 'together' ? 'All at once: Inbox, Drafts, and Sent rise together. No waiting.' : '50ms stagger: Inbox moves first. Drafts waits 50ms. Sent waits 100ms.'}
+        {mode === 'together'
+          ? `All at once: Inbox, Drafts, and Sent slide ${STAGGER_TRAVEL_PX}px together. No waiting.`
+          : `50ms stagger: Inbox slides ${STAGGER_TRAVEL_PX}px first. Drafts waits 50ms. Sent waits 100ms. Watch the color bars travel.`}
       </p>
-      <ul data-stagger-mode={mode} className="space-y-3">
+      <ul data-stagger-mode={mode} data-stagger-well="" className="space-y-3">
         {items.map((row) => {
           const delay = mode === 'stagger' && !reduced ? row.delay : 0;
+          const x = go ? toX : fromX;
           return (
-            <li key={row.label} data-stagger-row={row.label} data-stagger-delay={`${delay}ms`} className={`flex items-center justify-between overflow-hidden rounded-xl border border-zinc-200 ${row.well} text-base font-semibold text-zinc-900 shadow-sm dark:border-zinc-700 dark:text-zinc-50`} style={{ opacity: go ? 1 : 0, transform: go ? 'translateX(0)' : 'translateX(-36px)', transitionProperty: 'opacity, transform', transitionDuration: reduced ? '0ms' : '520ms', transitionTimingFunction: 'ease-out', transitionDelay: `${delay}ms` }}>
-              <span className="inline-flex min-h-[52px] items-center gap-3 px-4">
-                <span className={`h-8 w-1.5 rounded-full ${row.bar}`} aria-hidden />
-                {row.label}
-              </span>
-              <span className="mr-3 rounded-full bg-zinc-900 px-2.5 py-1 text-sm font-bold tabular-nums text-white dark:bg-white dark:text-zinc-900">{delay}ms</span>
+            <li
+              key={row.label}
+              data-stagger-row={row.label}
+              data-stagger-delay={`${delay}ms`}
+              className={`rounded-xl border border-zinc-200 ${row.well} text-base font-semibold text-zinc-900 shadow-sm dark:border-zinc-700 dark:text-zinc-50`}
+            >
+              <div
+                data-stagger-mover=""
+                data-stagger-travel={String(STAGGER_TRAVEL_PX)}
+                data-stagger-from={`translateX(${fromX})`}
+                data-stagger-to={`translateX(${toX})`}
+                className="flex items-center justify-between"
+                style={{
+                  width: `calc(100% - ${STAGGER_TRAVEL_PX}px)`,
+                  opacity: 1,
+                  transform: `translateX(${x})`,
+                  transitionProperty: 'transform',
+                  transitionDuration: reduced ? '0ms' : `${STAGGER_DURATION_MS}ms`,
+                  transitionTimingFunction: 'ease-out',
+                  transitionDelay: `${delay}ms`,
+                }}
+              >
+                <span className="inline-flex min-h-[52px] items-center gap-3 px-4">
+                  <span className={`h-8 w-1.5 rounded-full ${row.bar}`} aria-hidden />
+                  {row.label}
+                </span>
+                <span className="mr-3 rounded-full bg-zinc-900 px-2.5 py-1 text-sm font-bold tabular-nums text-white dark:bg-white dark:text-zinc-900">{delay}ms</span>
+              </div>
             </li>
           );
         })}
@@ -469,8 +510,8 @@ function ConfettiPreview({ reduced }) {
   const [burst, setBurst] = useState(false);
   const [toast, setToast] = useState(false);
   const [fly, setFly] = useState(false);
-  const colors = ['bg-indigo-500', 'bg-amber-400', 'bg-emerald-400', 'bg-rose-500', 'bg-sky-400', 'bg-violet-500'];
-  const bits = Array.from({ length: 36 }, (_, i) => i);
+  const colors = ['bg-indigo-400', 'bg-amber-300', 'bg-emerald-300', 'bg-rose-400', 'bg-sky-300', 'bg-white'];
+  const bits = Array.from({ length: CONFETTI_COUNT }, (_, i) => i);
 
   useEffect(() => {
     if (!burst || reduced) {
@@ -505,22 +546,34 @@ function ConfettiPreview({ reduced }) {
       <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
         Tap Complete order for a bright burst. Replay to arm it again.
       </p>
-      <div className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 px-5 py-12 dark:border-zinc-700" data-confetti-stage="">
+      <div
+        className="relative flex min-h-[24rem] items-center justify-center overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 px-5 py-10 dark:border-zinc-700"
+        data-confetti-stage=""
+        data-confetti-spread={String(CONFETTI_SPREAD_PX)}
+        data-confetti-count={String(CONFETTI_COUNT)}
+      >
         {burst && !reduced && bits.map((i) => {
-          const angle = (i / 36) * Math.PI * 2;
-          const dist = 88 + (i % 5) * 14;
-          const wide = i % 3 === 1;
+          const angle = (i / CONFETTI_COUNT) * Math.PI * 2;
+          const dist = CONFETTI_SPREAD_PX + (i % 5) * 16;
+          const size = i % 3 === 0 ? CONFETTI_SIZE_PX + 6 : CONFETTI_SIZE_PX;
+          const tall = i % 2 === 0 ? size : Math.round(size * 0.55);
           return (
             <span
               key={i}
               data-confetti-bit=""
               data-confetti-color={colors[i % colors.length]}
+              data-confetti-size={String(size)}
+              data-confetti-duration={String(CONFETTI_FLY_MS + CONFETTI_FADE_MS)}
               aria-hidden
-              className={`pointer-events-none absolute left-1/2 top-1/2 ${wide ? 'h-3 w-5' : 'h-3.5 w-3.5'} ${i % 2 === 0 ? 'rounded-full' : 'rounded-sm'} ${colors[i % colors.length]}`}
+              className={`pointer-events-none absolute left-1/2 top-1/2 ${i % 2 === 0 ? 'rounded-full' : 'rounded-sm'} ${colors[i % colors.length]}`}
               style={{
-                transform: fly ? `translate(${Math.cos(angle) * dist}px, ${Math.sin(angle) * dist - 28}px) rotate(${i * 24}deg)` : 'translate(-50%, -50%)',
+                width: `${size}px`,
+                height: `${tall}px`,
+                transform: fly
+                  ? `translate(${Math.cos(angle) * dist}px, ${Math.sin(angle) * dist - 36}px) rotate(${i * 28}deg)`
+                  : 'translate(-50%, -50%)',
                 opacity: fly ? 0 : 1,
-                transition: 'transform 900ms ease-out, opacity 900ms ease-out',
+                transition: `transform ${CONFETTI_FLY_MS}ms ease-out, opacity ${CONFETTI_FADE_MS}ms linear ${CONFETTI_FADE_DELAY_MS}ms`,
               }}
             />
           );
@@ -656,7 +709,8 @@ export default function MotionPatternDemo({ demoId }) {
   }
 
   const fill = demoId === 'parallax' || demoId === 'scrollreveal';
-  return <Frame title={title} fill={fill}>{body}</Frame>;
+  const clip = demoId !== 'stagger';
+  return <Frame title={title} fill={fill} clip={clip}>{body}</Frame>;
 }
 
 export { EASING_TRAVELERS };

--- a/src/test/MotionPatternDemo.test.jsx
+++ b/src/test/MotionPatternDemo.test.jsx
@@ -1,6 +1,17 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import MotionPatternDemo, { EASING_TRAVELERS } from '../components/demos/MotionPatternDemo';
+import MotionPatternDemo, {
+  EASING_TRAVELERS,
+  STAGGER_TRAVEL_PX,
+  STAGGER_DURATION_MS,
+  STAGGER_STEP_MS,
+  CONFETTI_COUNT,
+  CONFETTI_SIZE_PX,
+  CONFETTI_SPREAD_PX,
+  CONFETTI_FLY_MS,
+  CONFETTI_FADE_DELAY_MS,
+  CONFETTI_FADE_MS,
+} from '../components/demos/MotionPatternDemo';
 
 function mockMotion(reduce) {
   window.matchMedia = vi.fn().mockImplementation((query) => ({
@@ -67,10 +78,34 @@ describe('#25 motion pattern previews are real', () => {
     expect([...rows].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '50ms', '100ms']);
     expect(new Set([...rows].map((r) => r.getAttribute('data-stagger-delay'))).size).toBe(3);
     expect(document.querySelector('[data-stagger-mode="stagger"]')).toBeTruthy();
-    expect(screen.getByText(/Inbox moves first/i)).toBeInTheDocument();
+    expect(screen.getByText(/Inbox slides 80px first/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Play all at once/i }));
     expect([...document.querySelectorAll('[data-stagger-row]')].every((r) => r.getAttribute('data-stagger-delay') === '0ms')).toBe(true);
     expect(screen.getByRole('button', { name: /Replay stagger/i })).toBeInTheDocument();
+  });
+
+  it('#34 stagger travel is a large measurable px slide, list stays visible', () => {
+    expect(STAGGER_TRAVEL_PX).toBeGreaterThanOrEqual(24);
+    expect(STAGGER_DURATION_MS).toBeGreaterThanOrEqual(700);
+    expect(STAGGER_STEP_MS).toBe(50);
+    render(<MotionPatternDemo demoId="stagger" />);
+    expect(screen.getByText('Inbox')).toBeVisible();
+    expect(screen.getByText('Drafts')).toBeVisible();
+    expect(screen.getByText('Sent')).toBeVisible();
+    const movers = document.querySelectorAll('[data-stagger-mover]');
+    expect(movers).toHaveLength(3);
+    movers.forEach((el) => {
+      const travel = Number(el.getAttribute('data-stagger-travel'));
+      expect(travel).toBeGreaterThanOrEqual(24);
+      expect(travel).toBe(STAGGER_TRAVEL_PX);
+      expect(el.style.opacity).toBe('1');
+      expect(el.style.transform).toMatch(/translateX\((\d+)px\)/);
+      const px = Number(el.style.transform.match(/translateX\((\d+)px\)/)[1]);
+      expect(px === 0 || px >= 24).toBe(true);
+      expect(el.getAttribute('data-stagger-from')).toBe(`translateX(${STAGGER_TRAVEL_PX}px)`);
+      expect(el.getAttribute('data-stagger-to')).toBe('translateX(0px)');
+      expect(el.style.transitionDuration).toBe(`${STAGGER_DURATION_MS}ms`);
+    });
   });
 
   it('Scroll Reveal is its own scroll panel with Reset', () => {
@@ -115,11 +150,34 @@ describe('#25 motion pattern previews are real', () => {
     expect(screen.queryByText('Order complete')).toBeNull();
     await user.click(screen.getByRole('button', { name: 'Complete order' }));
     expect(screen.getByText('Order complete')).toBeInTheDocument();
-    expect(document.querySelectorAll('[data-confetti-bit]').length).toBeGreaterThanOrEqual(24);
+    expect(document.querySelectorAll('[data-confetti-bit]').length).toBe(CONFETTI_COUNT);
     const burstColors = new Set([...document.querySelectorAll('[data-confetti-color]')].map((el) => el.getAttribute('data-confetti-color')));
     expect(burstColors.size).toBeGreaterThanOrEqual(4);
     expect(screen.getByRole('button', { name: /Replay confetti/i })).toBeInTheDocument();
     expect(screen.getByText(/Fires once on a real win/i)).toBeInTheDocument();
+  });
+
+  it('#35 confetti pieces are large, wide, and stay on screen', async () => {
+    const user = userEvent.setup();
+    expect(CONFETTI_COUNT).toBeGreaterThanOrEqual(20);
+    expect(CONFETTI_SIZE_PX).toBeGreaterThanOrEqual(16);
+    expect(CONFETTI_SPREAD_PX).toBeGreaterThanOrEqual(120);
+    expect(CONFETTI_FLY_MS).toBeGreaterThanOrEqual(1600);
+    expect(CONFETTI_FADE_DELAY_MS).toBeGreaterThanOrEqual(1000);
+    expect(CONFETTI_FADE_MS).toBeGreaterThanOrEqual(400);
+    render(<MotionPatternDemo demoId="confetti" />);
+    await user.click(screen.getByRole('button', { name: 'Complete order' }));
+    const stage = document.querySelector('[data-confetti-stage]');
+    expect(Number(stage.getAttribute('data-confetti-spread'))).toBeGreaterThanOrEqual(120);
+    expect(Number(stage.getAttribute('data-confetti-count'))).toBe(CONFETTI_COUNT);
+    const bits = [...document.querySelectorAll('[data-confetti-bit]')];
+    expect(bits.length).toBeGreaterThanOrEqual(20);
+    bits.forEach((el) => {
+      expect(Number(el.getAttribute('data-confetti-size'))).toBeGreaterThanOrEqual(16);
+      expect(parseInt(el.style.width, 10)).toBeGreaterThanOrEqual(16);
+      expect(Number(el.getAttribute('data-confetti-duration'))).toBeGreaterThanOrEqual(1600);
+      expect(el.style.transition).toMatch(/1600ms/);
+    });
   });
 
   it('Hover Micro still lifts on hover', () => {

--- a/src/test/hosting.test.js
+++ b/src/test/hosting.test.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const firebase = JSON.parse(readFileSync(resolve(process.cwd(), 'firebase.json'), 'utf8'));
+const indexHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+
+function headerFor(source) {
+  return (firebase.hosting.headers || []).find((h) => h.source === source);
+}
+
+function cacheControl(source) {
+  const rule = headerFor(source);
+  const row = rule?.headers?.find((h) => h.key === 'Cache-Control');
+  return row?.value || '';
+}
+
+describe('#37 hashed-bundle deploys must not white-screen return visitors', () => {
+  it('sends no-cache on HTML and immutable on hashed assets', () => {
+    const htmlCache = cacheControl('**');
+    expect(htmlCache).toMatch(/no-cache|max-age=0/);
+    expect(htmlCache).toMatch(/must-revalidate/);
+    const assets = cacheControl('/assets/**');
+    expect(assets).toMatch(/max-age=31536000/);
+    expect(assets).toMatch(/immutable/);
+  });
+
+  it('does not rewrite missing /assets/*.js to the SPA HTML', () => {
+    const rewrites = firebase.hosting.rewrites || [];
+    expect(rewrites.some((r) => r.source === '**')).toBe(false);
+    expect(rewrites.some((r) => String(r.source || '').includes('/assets'))).toBe(false);
+    expect(rewrites.some((r) => String(r.regex || '').includes('assets'))).toBe(false);
+    const dests = rewrites.filter((r) => r.destination === '/index.html').map((r) => r.source);
+    expect(dests).toEqual(expect.arrayContaining(['/', '/glossary/**', '/build/**']));
+    dests.forEach((src) => {
+      expect(src).not.toBe('**');
+      expect(String(src)).not.toMatch(/assets/);
+    });
+  });
+
+  it('index.html has an inline boot check with a refresh fallback', () => {
+    expect(indexHtml).toMatch(/data-boot-fallback/);
+    expect(indexHtml).toMatch(/script\[type="module"\]/);
+    expect(indexHtml).toMatch(/location\.reload/);
+    expect(indexHtml).toMatch(/This page needs a refresh/);
+  });
+});


### PR DESCRIPTION
## Summary
- **#34 Stagger:** Rows stay visible (opacity 1). Inner mover travels a real **80px** `translateX` over **900ms**, in-bounds so overflow cannot clip it to 2-4px. 50ms / 100ms delays stay. Replay and All-at-once stay.
- **#35 Confetti:** 28 pieces, **22-28px**, **200px+** spread, high-contrast colors on zinc-950. Stay opaque **1.6s**, fade over 0.7s (total ~2.3s). Still one-shot. Replay stays.
- **#37 Hosting:** `Cache-Control: no-cache, max-age=0, must-revalidate` on HTML. Hashed `/assets/**` stay `immutable`. SPA rewrites are only `/`, `/glossary/**`, `/build/**`, `/components/**` so missing `/assets/*.js` 404s instead of returning HTML. Tiny inline boot check offers Refresh if `#root` never mounts.

Cites DESIGN.md (readable at a glance, not tiny stubs) and CLAUDE.md (previews must teach at a glance; deploy is the product).

## Test plan
- [x] `npm test` — 1301 passed, including travel >= 24px, confetti size/count/duration, firebase.json header/rewrite snapshot
- [ ] Tess live: `/glossary/stagger` — color bars travel tens of px, cascade visible, list never blanks
- [ ] Tess live: `/glossary/confetti` — burst is obvious at a glance, then gone; Replay re-arms
- [ ] After deploy, a cached tab should get new `index.html` (no-cache) and not request a missing hashed JS as HTML

Closes #34
Closes #35
Closes #37