### PR TITLE
fix: commit stagger start frame and stretch the cascade (#34)

### DIFF
--- a/src/components/demos/MotionPatternDemo.jsx
+++ b/src/components/demos/MotionPatternDemo.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 
 function prefersReducedMotion() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
@@ -57,7 +58,28 @@ function kick(setGo) {
 // measurable in px, not a 2-4px fade stub. DESIGN.md: readable at a glance.
 export const STAGGER_TRAVEL_PX = 80;
 export const STAGGER_DURATION_MS = 900;
-export const STAGGER_STEP_MS = 50;
+export const STAGGER_STEP_MS = 200;
+
+/**
+ * Tess #34: snap to translateX(start), let that frame paint, then play to 0.
+ * Replay must do this or the start never commits (2-5px cancel, empty getAnimations).
+ */
+export function commitStartThenPlay(setPhase, flushRoot) {
+  let cancelled = false;
+  flushSync(() => setPhase('start'));
+  if (flushRoot) void flushRoot.offsetWidth;
+  requestAnimationFrame(() => {
+    if (cancelled) return;
+    if (flushRoot) void flushRoot.offsetWidth;
+    requestAnimationFrame(() => {
+      if (cancelled) return;
+      setPhase('end');
+    });
+  });
+  return () => {
+    cancelled = true;
+  };
+}
 
 export const CONFETTI_COUNT = 28;
 export const CONFETTI_SIZE_PX = 22;
@@ -198,38 +220,65 @@ function StaggerPreview({ reduced }) {
     { label: 'Sent', delay: STAGGER_STEP_MS * 2, bar: 'bg-sky-500', well: 'bg-sky-50 dark:bg-sky-950/40' },
   ];
   const [mode, setMode] = useState('stagger');
-  const [go, setGo] = useState(false);
-  const replay = useCallback(() => kick(setGo), []);
-  useEffect(() => { replay(); }, [replay, mode]);
+  const [phase, setPhase] = useState('start');
+  const wellRef = useRef(null);
+  const cancelRef = useRef(null);
+
+  const replay = useCallback(() => {
+    if (cancelRef.current) cancelRef.current();
+    if (reduced) {
+      setPhase('end');
+      return;
+    }
+    cancelRef.current = commitStartThenPlay(setPhase, wellRef.current);
+  }, [reduced]);
+
+  useEffect(() => {
+    replay();
+    return () => {
+      if (cancelRef.current) cancelRef.current();
+    };
+  }, [replay, mode]);
 
   const fromX = `${STAGGER_TRAVEL_PX}px`;
   const toX = '0px';
+  const atStart = phase === 'start' && !reduced;
 
   return (
-    <div className="w-full max-w-lg space-y-4">
+    <div className="min-w-0 w-full max-w-lg space-y-4">
       <div className="flex flex-wrap items-center gap-1">
         <ChipButton onClick={() => setMode('together')} pressed={mode === 'together'} label="Play all at once">
           All at once
         </ChipButton>
-        <ChipButton onClick={() => setMode('stagger')} pressed={mode === 'stagger'} label="Play 50 millisecond stagger">
-          50ms stagger
+        <ChipButton onClick={() => setMode('stagger')} pressed={mode === 'stagger'} label="Play 200 millisecond stagger">
+          200ms stagger
         </ChipButton>
         <button type="button" onClick={replay} aria-label="Replay stagger" className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-indigo-600 px-4 text-sm font-semibold text-white hover:bg-indigo-500">Replay</button>
       </div>
-      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+      <p
+        data-stagger-teach=""
+        className="whitespace-normal break-words text-sm leading-relaxed text-zinc-600 dark:text-zinc-300"
+      >
         {mode === 'together'
           ? `All at once: Inbox, Drafts, and Sent slide ${STAGGER_TRAVEL_PX}px together. No waiting.`
-          : `50ms stagger: Inbox slides ${STAGGER_TRAVEL_PX}px first. Drafts waits 50ms. Sent waits 100ms. Watch the color bars travel.`}
+          : `200ms stagger: Inbox slides ${STAGGER_TRAVEL_PX}px first. Drafts waits 200ms. Sent waits 400ms. Watch Inbox, then Drafts, then Sent.`}
       </p>
-      <ul data-stagger-mode={mode} data-stagger-well="" className="space-y-3">
+      <ul
+        ref={wellRef}
+        data-stagger-mode={mode}
+        data-stagger-well=""
+        data-stagger-phase={atStart ? 'start' : 'end'}
+        className="space-y-3"
+      >
         {items.map((row) => {
-          const delay = mode === 'stagger' && !reduced ? row.delay : 0;
-          const x = go ? toX : fromX;
+          const shownDelay = mode === 'stagger' && !reduced ? row.delay : 0;
+          const playDelay = atStart ? 0 : shownDelay;
+          const x = atStart ? fromX : toX;
           return (
             <li
               key={row.label}
               data-stagger-row={row.label}
-              data-stagger-delay={`${delay}ms`}
+              data-stagger-delay={`${shownDelay}ms`}
               className={`rounded-xl border border-zinc-200 ${row.well} text-base font-semibold text-zinc-900 shadow-sm dark:border-zinc-700 dark:text-zinc-50`}
             >
               <div
@@ -237,22 +286,23 @@ function StaggerPreview({ reduced }) {
                 data-stagger-travel={String(STAGGER_TRAVEL_PX)}
                 data-stagger-from={`translateX(${fromX})`}
                 data-stagger-to={`translateX(${toX})`}
+                data-stagger-phase={atStart ? 'start' : 'end'}
                 className="flex items-center justify-between"
                 style={{
                   width: `calc(100% - ${STAGGER_TRAVEL_PX}px)`,
                   opacity: 1,
                   transform: `translateX(${x})`,
-                  transitionProperty: 'transform',
+                  transitionProperty: atStart ? 'none' : 'transform',
                   transitionDuration: reduced ? '0ms' : `${STAGGER_DURATION_MS}ms`,
                   transitionTimingFunction: 'ease-out',
-                  transitionDelay: `${delay}ms`,
+                  transitionDelay: `${playDelay}ms`,
                 }}
               >
                 <span className="inline-flex min-h-[52px] items-center gap-3 px-4">
                   <span className={`h-8 w-1.5 rounded-full ${row.bar}`} aria-hidden />
                   {row.label}
                 </span>
-                <span className="mr-3 rounded-full bg-zinc-900 px-2.5 py-1 text-sm font-bold tabular-nums text-white dark:bg-white dark:text-zinc-900">{delay}ms</span>
+                <span className="mr-3 rounded-full bg-zinc-900 px-2.5 py-1 text-sm font-bold tabular-nums text-white dark:bg-white dark:text-zinc-900">{shownDelay}ms</span>
               </div>
             </li>
           );

--- a/src/test/MotionPatternDemo.test.jsx
+++ b/src/test/MotionPatternDemo.test.jsx
@@ -1,10 +1,11 @@
-import { render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MotionPatternDemo, {
   EASING_TRAVELERS,
   STAGGER_TRAVEL_PX,
   STAGGER_DURATION_MS,
   STAGGER_STEP_MS,
+  commitStartThenPlay,
   CONFETTI_COUNT,
   CONFETTI_SIZE_PX,
   CONFETTI_SPREAD_PX,
@@ -75,7 +76,7 @@ describe('#25 motion pattern previews are real', () => {
     render(<MotionPatternDemo demoId="stagger" />);
     const rows = document.querySelectorAll('[data-stagger-row]');
     expect(rows).toHaveLength(3);
-    expect([...rows].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '50ms', '100ms']);
+    expect([...rows].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '200ms', '400ms']);
     expect(new Set([...rows].map((r) => r.getAttribute('data-stagger-delay'))).size).toBe(3);
     expect(document.querySelector('[data-stagger-mode="stagger"]')).toBeTruthy();
     expect(screen.getByText(/Inbox slides 80px first/i)).toBeInTheDocument();
@@ -87,7 +88,7 @@ describe('#25 motion pattern previews are real', () => {
   it('#34 stagger travel is a large measurable px slide, list stays visible', () => {
     expect(STAGGER_TRAVEL_PX).toBeGreaterThanOrEqual(24);
     expect(STAGGER_DURATION_MS).toBeGreaterThanOrEqual(700);
-    expect(STAGGER_STEP_MS).toBe(50);
+    expect(STAGGER_STEP_MS).toBeGreaterThanOrEqual(150);
     render(<MotionPatternDemo demoId="stagger" />);
     expect(screen.getByText('Inbox')).toBeVisible();
     expect(screen.getByText('Drafts')).toBeVisible();
@@ -106,6 +107,84 @@ describe('#25 motion pattern previews are real', () => {
       expect(el.getAttribute('data-stagger-to')).toBe('translateX(0px)');
       expect(el.style.transitionDuration).toBe(`${STAGGER_DURATION_MS}ms`);
     });
+  });
+
+  it('#34 Replay applies start translate before end', async () => {
+    const pending = [];
+    const origRaf = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb) => {
+      pending.push(cb);
+      return pending.length;
+    };
+
+    try {
+      render(<MotionPatternDemo demoId="stagger" />);
+      const movers = () => [...document.querySelectorAll('[data-stagger-mover]')];
+      movers().forEach((el) => {
+        expect(el.style.transform).toBe(`translateX(${STAGGER_TRAVEL_PX}px)`);
+        expect(el.getAttribute('data-stagger-phase')).toBe('start');
+        expect(el.style.transitionProperty).toBe('none');
+      });
+
+      await act(async () => {
+        const first = pending.splice(0);
+        first.forEach((cb) => cb(0));
+      });
+      await act(async () => {
+        const second = pending.splice(0);
+        second.forEach((cb) => cb(0));
+      });
+
+      movers().forEach((el) => {
+        expect(el.style.transform).toBe('translateX(0px)');
+        expect(el.getAttribute('data-stagger-phase')).toBe('end');
+        expect(el.style.transitionProperty).toBe('transform');
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Replay stagger/i }));
+      movers().forEach((el) => {
+        expect(el.style.transform).toBe(`translateX(${STAGGER_TRAVEL_PX}px)`);
+        expect(el.getAttribute('data-stagger-phase')).toBe('start');
+        expect(el.style.transitionProperty).toBe('none');
+      });
+    } finally {
+      window.requestAnimationFrame = origRaf;
+    }
+  });
+
+  it('#34 stagger delays are at least 150ms apart on the stagger path', () => {
+    expect(STAGGER_STEP_MS).toBeGreaterThanOrEqual(150);
+    expect(STAGGER_DURATION_MS).toBeGreaterThanOrEqual(800);
+    render(<MotionPatternDemo demoId="stagger" />);
+    const delays = [...document.querySelectorAll('[data-stagger-row]')].map((r) =>
+      parseInt(r.getAttribute('data-stagger-delay'), 10),
+    );
+    expect(delays).toEqual([0, STAGGER_STEP_MS, STAGGER_STEP_MS * 2]);
+    expect(delays[1] - delays[0]).toBeGreaterThanOrEqual(150);
+    expect(delays[2] - delays[1]).toBeGreaterThanOrEqual(150);
+    const teach = document.querySelector('[data-stagger-teach]');
+    expect(teach.className).toMatch(/break-words/);
+    expect(teach.className).not.toMatch(/truncate|whitespace-nowrap/);
+  });
+
+  it('#34 commitStartThenPlay paints start before end', () => {
+    const phases = [];
+    const pending = [];
+    const origRaf = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb) => {
+      pending.push(cb);
+      return pending.length;
+    };
+    try {
+      commitStartThenPlay((p) => phases.push(p), null);
+      expect(phases).toEqual(['start']);
+      pending.shift()(0);
+      expect(phases).toEqual(['start']);
+      pending.shift()(0);
+      expect(phases).toEqual(['start', 'end']);
+    } finally {
+      window.requestAnimationFrame = origRaf;
+    }
   });
 
   it('Scroll Reveal is its own scroll panel with Reset', () => {


### PR DESCRIPTION
Cites DESIGN.md: live demos must be readable at a glance, not tiny demo stubs. Replay commits translateX(80px) for a painted frame (flushSync + layout flush + double-rAF, transition none on start) then animates to 0. Default stagger is 200ms between items, duration 900ms. Teaching line wraps. Tests cover start-before-end Replay and delays >= 150ms. Closes #34. Do not merge or deploy from this note.