### PR TITLE
fix: wrap header topic pills on spaces, not mid-word (#42 #43)

### DIFF
--- a/src/components/layout/TopNav.jsx
+++ b/src/components/layout/TopNav.jsx
@@ -93,9 +93,10 @@ function PillDropdown({
   // Icon-only pills ignore this.
   labelFrom = 'lg',
   // DESIGN.md Layout: titles and tags wrap. Do not clip to half a word.
-  // min-w keeps a real word visible; max-w wraps long titles so the left
-  // cluster cannot cover What's New / VibeScore.
-  labelMaxClass = 'min-w-[5.5rem] max-w-[7rem] lg:max-w-[10rem] xl:max-w-[12rem]',
+  // min-content grows the pill to a whole word (Overlays, Celebration);
+  // 5.5rem keeps short labels like Easing from collapsing. max-w wraps
+  // multi-word titles at spaces so the left cluster cannot cover What's New / VibeScore.
+  labelMaxClass = 'min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]',
 }) {
   const wrapRef = useRef(null);
   const labelBp = iconOnly ? null : (LABEL_FROM[labelFrom] || LABEL_FROM.xl);
@@ -117,7 +118,7 @@ function PillDropdown({
   }, [isOpen, onClose]);
 
   return (
-    <div ref={wrapRef} className={`relative ${iconOnly ? 'min-w-0' : 'min-w-[5.5rem] max-w-full'}`}>
+    <div ref={wrapRef} className={`relative ${iconOnly ? 'min-w-0' : 'min-w-[max(5.5rem,min-content)] max-w-full'}`}>
       <button
         onClick={onToggle}
         aria-label={ariaLabel || label}
@@ -129,7 +130,7 @@ function PillDropdown({
       >
         {icon}
         {!iconOnly && labelBp && (
-          <span className={`${labelBp.label} ${labelMaxClass} whitespace-normal break-words leading-tight text-left align-middle`}>
+          <span className={`${labelBp.label} ${labelMaxClass} whitespace-normal break-keep leading-tight text-left align-middle`}>
             {label}
           </span>
         )}
@@ -694,7 +695,7 @@ export default function TopNav({
         <div className={`absolute inset-0 bg-gradient-to-r ${catColors.gradient} opacity-[0.10] dark:opacity-[0.18] transition-opacity duration-500`} />
       </div>
       <div className="relative flex items-center justify-between gap-2 px-3 sm:px-4 md:px-6 min-h-20">
-        {/* Left: Logo + pills. min-w-0 flex-1 keeps this cluster from covering Whats New / VibeScore. Do not overflow-hidden this ancestor: category dropdowns are absolute and would clip. Titles wrap on the label spans (DESIGN.md). */}
+        {/* Left: Logo + pills. min-w-0 flex-1 keeps this cluster from covering Whats New / VibeScore. Do not overflow-hidden this ancestor: category dropdowns are absolute and would clip. Titles wrap on spaces (DESIGN.md). min-h-20 grows with a wrapped label so the panes below stay visible (#43). */}
         <div data-testid="nav-left-cluster" className="flex items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0 flex-1 overflow-visible pr-2">
           <button
             onClick={onGetStarted}
@@ -743,7 +744,7 @@ export default function TopNav({
 
           {/* Category */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block min-w-0">
+          <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
             <PillDropdown
               icon={
                 <span className={`flex items-center gap-1.5 ${catColors.accent}`}>
@@ -753,7 +754,7 @@ export default function TopNav({
               }
               label={activeCat?.name || 'Overlays'}
               labelFrom="lg"
-              labelMaxClass="min-w-[5.5rem] max-w-[7rem] lg:max-w-[10rem] xl:max-w-[14rem]"
+              labelMaxClass="min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]"
               isOpen={openDropdown === 'category'}
               onToggle={() => setOpenDropdown(openDropdown === 'category' ? null : 'category')}
               onClose={() => setOpenDropdown(null)}
@@ -785,7 +786,7 @@ export default function TopNav({
 
           {/* Component */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block min-w-[5.5rem]">
+          <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
             <PillDropdown
               icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
               label={activeItemData?.name || 'Modal'}
@@ -821,7 +822,7 @@ export default function TopNav({
 
           {/* Build literacy: Cluster pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block min-w-0">
+            <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
               <PillDropdown
                 icon={
                   <span className={`flex items-center gap-1.5 ${activeBuildColors.accent}`}>
@@ -831,7 +832,7 @@ export default function TopNav({
                 }
                 label={activeBuildCluster?.title || 'Web foundations'}
                 labelFrom="lg"
-                labelMaxClass="min-w-[5.5rem] max-w-[7rem] lg:max-w-[10rem] xl:max-w-[14rem]"
+                labelMaxClass="min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]"
                 isOpen={openDropdown === 'build-cluster'}
                 onToggle={() => setOpenDropdown(openDropdown === 'build-cluster' ? null : 'build-cluster')}
                 onClose={() => setOpenDropdown(null)}
@@ -865,7 +866,7 @@ export default function TopNav({
 
           {/* Build literacy: Topic pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block min-w-[5.5rem]">
+            <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
               <PillDropdown
                 icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
                 label={activeBuildTopicData?.title || 'Pick a topic'}

--- a/src/test/TopNav.test.jsx
+++ b/src/test/TopNav.test.jsx
@@ -125,9 +125,10 @@ describe('#33 header topic pill shows a real word', () => {
     const label = [...pill.querySelectorAll('span')].find((el) => el.textContent === 'Easing');
     expect(label).toBeTruthy();
     expect(label.className).not.toMatch(/\btruncate\b/);
-    expect(label.className).toMatch(/break-words/);
+    expect(label.className).toMatch(/break-keep/);
+    expect(label.className).not.toMatch(/break-words/);
     expect(label.className).toMatch(/whitespace-normal/);
-    expect(label.className).toMatch(/min-w-\[5\.5rem\]/);
+    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
     expect(label.className).toMatch(/hidden lg:inline-block/);
   });
 
@@ -143,5 +144,87 @@ describe('#33 header topic pill shows a real word', () => {
     expect(right.className).toMatch(/shrink-0/);
     expect(screen.getByRole('button', { name: /What'?s new/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /VibeScore/i })).toBeInTheDocument();
+  });
+});
+
+describe('#42 header topic pill wraps on spaces, not mid-word', () => {
+  const assertWrapAtSpaces = (label) => {
+    expect(label).toBeTruthy();
+    expect(label.className).toMatch(/whitespace-normal/);
+    expect(label.className).toMatch(/break-keep/);
+    expect(label.className).not.toMatch(/break-words/);
+    expect(label.className).not.toMatch(/break-all/);
+    expect(label.className).not.toMatch(/\btruncate\b/);
+    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
+  };
+
+  it('keeps Overlays as a whole word and still wraps Modal / Dialog at the space', () => {
+    render(<TopNav {...defaultProps()} activeItem="modal" />);
+
+    const overlaysPill = screen.getByRole('button', { name: 'Overlays' });
+    expect(overlaysPill).toHaveTextContent('Overlays');
+    const overlaysLabel = [...overlaysPill.querySelectorAll('span')].find((el) => el.textContent === 'Overlays');
+    assertWrapAtSpaces(overlaysLabel);
+
+    const topicPill = screen.getByRole('button', { name: 'Modal / Dialog' });
+    expect(topicPill).toHaveTextContent('Modal / Dialog');
+    const topicLabel = [...topicPill.querySelectorAll('span')].find((el) => el.textContent === 'Modal / Dialog');
+    assertWrapAtSpaces(topicLabel);
+    expect(topicPill.className).toMatch(/text-base/);
+    expect(topicPill.className).not.toMatch(/text-\[10px\]/);
+    expect(topicPill.className).not.toMatch(/text-\[8px\]/);
+  });
+
+  it('keeps Celebration as a whole word on Confetti / Celebration', () => {
+    render(<TopNav {...defaultProps()} activeItem="confetti" activeCatColors={CATEGORY_COLORS.motion} />);
+
+    const topicPill = screen.getByRole('button', { name: 'Confetti / Celebration' });
+    expect(topicPill).toHaveTextContent('Confetti / Celebration');
+    expect(topicPill.textContent).toMatch(/Celebration/);
+    expect(topicPill.textContent).not.toMatch(/Celebrat(?!ion)/);
+    const topicLabel = [...topicPill.querySelectorAll('span')].find((el) => el.textContent === 'Confetti / Celebration');
+    assertWrapAtSpaces(topicLabel);
+    expect(topicPill.className).toMatch(/text-base/);
+    expect(topicPill.className).toMatch(/md:text-lg/);
+  });
+
+  it('does not cover What\'s New / VibeScore when long labels wrap', () => {
+    render(<TopNav {...defaultProps()} activeItem="confetti" activeCatColors={CATEGORY_COLORS.motion} />);
+
+    const left = screen.getByTestId('nav-left-cluster');
+    expect(left.className).toMatch(/min-w-0/);
+    expect(left.className).toMatch(/flex-1/);
+    expect(left.className).toMatch(/overflow-visible/);
+    expect(left.className).not.toMatch(/overflow-hidden/);
+
+    const right = screen.getByTestId('nav-right-cluster');
+    expect(right.className).toMatch(/shrink-0/);
+    expect(screen.getByRole('button', { name: /What'?s new/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /VibeScore/i })).toBeInTheDocument();
+  });
+});
+
+describe('#43 wrapped header stays in flow above the panes', () => {
+  it('keeps min-h-20 and does not pin or clip the header over the Try It pane', () => {
+    const { container } = render(
+      <TopNav {...defaultProps()} activeItem="confetti" activeCatColors={CATEGORY_COLORS.motion} />
+    );
+
+    const header = container.querySelector('header');
+    expect(header).toBeTruthy();
+    expect(header.className).toMatch(/shrink-0/);
+    expect(header.className).toMatch(/\brelative\b/);
+    expect(header.className).not.toMatch(/\bfixed\b/);
+    expect(header.className).not.toMatch(/\babsolute\b/);
+    expect(header.className).not.toMatch(/overflow-hidden/);
+
+    const bar = header.querySelector('[class*="min-h-20"]');
+    expect(bar).toBeTruthy();
+    expect(bar.className).toMatch(/min-h-20/);
+    expect(bar.className).not.toMatch(/(?:^|\s)h-20(?:\s|$)/);
+
+    const topicLabel = [...container.querySelectorAll('span')].find((el) => el.textContent === 'Confetti / Celebration');
+    expect(topicLabel.className).toMatch(/break-keep/);
+    expect(topicLabel.className).not.toMatch(/break-words/);
   });
 });


### PR DESCRIPTION
Header topic pills wrap on spaces only (break-keep, not break-words). The pill grows to a real word so Overlays and Celebration stay whole. Long titles wrap at the space (two lines max). Left cluster still min-w-0 flex-1 overflow-visible; right cluster stays shrink-0 so Whats New / VibeScore are not covered. Header stays min-h-20 and in flow so Confetti Complete order / Replay stay visible.

Closes #42.
Closes #43.

Cite: DESIGN.md Layout (titles and tags wrap; do not clip to half a word; desktop fills the window; preview grows). Typography: nothing below text-xs.