### PR TITLE
fix: honor prefers-reduced-motion on stagger Replay (#44)

### DIFF
--- a/src/components/demos/MotionPatternDemo.jsx
+++ b/src/components/demos/MotionPatternDemo.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { flushSync } from 'react-dom';
 
 function prefersReducedMotion() {
@@ -8,6 +8,27 @@ function prefersReducedMotion() {
   } catch {
     return false;
   }
+}
+
+function subscribeReducedMotion(onStoreChange) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+  try {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => onStoreChange();
+    if (typeof mq.addEventListener === 'function') mq.addEventListener('change', handler);
+    else if (typeof mq.addListener === 'function') mq.addListener(handler);
+    return () => {
+      if (typeof mq.removeEventListener === 'function') mq.removeEventListener('change', handler);
+      else if (typeof mq.removeListener === 'function') mq.removeListener(handler);
+    };
+  } catch {
+    return () => {};
+  }
+}
+
+/** Live OS preference. Replay must not close over a stale first-paint value. */
+function usePrefersReducedMotion() {
+  return useSyncExternalStore(subscribeReducedMotion, prefersReducedMotion, () => false);
 }
 
 function Frame({ title, children, fill = false, clip = true }) {
@@ -213,7 +234,7 @@ function ParallaxPreview({ reduced }) {
   );
 }
 
-function StaggerPreview({ reduced }) {
+function StaggerPreview({ reduced: reducedProp }) {
   const items = [
     { label: 'Inbox', delay: 0, bar: 'bg-indigo-600', well: 'bg-white dark:bg-zinc-900' },
     { label: 'Drafts', delay: STAGGER_STEP_MS, bar: 'bg-indigo-500', well: 'bg-indigo-50 dark:bg-indigo-950/60' },
@@ -223,10 +244,14 @@ function StaggerPreview({ reduced }) {
   const [phase, setPhase] = useState('start');
   const wellRef = useRef(null);
   const cancelRef = useRef(null);
+  // Re-read matchMedia here. A first-paint `reduced` prop is not enough:
+  // DevTools / OS can flip prefers-reduced-motion after mount (#44).
+  const reduced = usePrefersReducedMotion() || reducedProp;
 
   const replay = useCallback(() => {
     if (cancelRef.current) cancelRef.current();
-    if (reduced) {
+    // Honor the live OS preference on Replay, not a stale render-time flag.
+    if (prefersReducedMotion() || reduced) {
       setPhase('end');
       return;
     }
@@ -292,7 +317,7 @@ function StaggerPreview({ reduced }) {
                   width: `calc(100% - ${STAGGER_TRAVEL_PX}px)`,
                   opacity: 1,
                   transform: `translateX(${x})`,
-                  transitionProperty: atStart ? 'none' : 'transform',
+                  transitionProperty: (atStart || reduced) ? 'none' : 'transform',
                   transitionDuration: reduced ? '0ms' : `${STAGGER_DURATION_MS}ms`,
                   transitionTimingFunction: 'ease-out',
                   transitionDelay: `${playDelay}ms`,

--- a/src/test/MotionPatternDemo.test.jsx
+++ b/src/test/MotionPatternDemo.test.jsx
@@ -15,14 +15,31 @@ import MotionPatternDemo, {
 } from '../components/demos/MotionPatternDemo';
 
 function mockMotion(reduce) {
-  window.matchMedia = vi.fn().mockImplementation((query) => ({
-    matches: reduce && String(query).includes('prefers-reduced-motion'),
-    media: query,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-  }));
+  let matchesReduce = !!reduce;
+  const listeners = new Set();
+  window.matchMedia = vi.fn().mockImplementation((query) => {
+    const isReduceQuery = String(query).includes('prefers-reduced-motion');
+    return {
+      get matches() {
+        return isReduceQuery && matchesReduce;
+      },
+      media: query,
+      addEventListener: (event, cb) => {
+        if (event === 'change') listeners.add(cb);
+      },
+      removeEventListener: (event, cb) => {
+        if (event === 'change') listeners.delete(cb);
+      },
+      addListener: (cb) => listeners.add(cb),
+      removeListener: (cb) => listeners.delete(cb),
+    };
+  });
+  return {
+    setReduce(next) {
+      matchesReduce = !!next;
+      listeners.forEach((cb) => cb({ matches: matchesReduce }));
+    },
+  };
 }
 
 beforeEach(() => {
@@ -185,6 +202,89 @@ describe('#25 motion pattern previews are real', () => {
     } finally {
       window.requestAnimationFrame = origRaf;
     }
+  });
+
+  it('#44 reduce-on Replay skips the 80px/900ms cascade and keeps rows visible', () => {
+    mockMotion(true);
+    render(<MotionPatternDemo demoId="stagger" />);
+    expect(screen.getByText('Inbox')).toBeVisible();
+    expect(screen.getByText('Drafts')).toBeVisible();
+    expect(screen.getByText('Sent')).toBeVisible();
+    const movers = () => [...document.querySelectorAll('[data-stagger-mover]')];
+    movers().forEach((el) => {
+      expect(el.style.opacity).toBe('1');
+      expect(el.style.transform).toBe('translateX(0px)');
+      expect(el.style.transitionDuration).toBe('0ms');
+      expect(el.getAttribute('data-stagger-phase')).toBe('end');
+    });
+    expect([...document.querySelectorAll('[data-stagger-row]')].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '0ms', '0ms']);
+
+    fireEvent.click(screen.getByRole('button', { name: /Replay stagger/i }));
+
+    movers().forEach((el) => {
+      expect(el.style.transform).toBe('translateX(0px)');
+      expect(el.style.transform).not.toBe(`translateX(${STAGGER_TRAVEL_PX}px)`);
+      expect(el.style.transitionDuration).toBe('0ms');
+      expect(el.style.transitionDuration).not.toBe(`${STAGGER_DURATION_MS}ms`);
+      expect(el.style.opacity).toBe('1');
+      expect(el.getAttribute('data-stagger-phase')).toBe('end');
+    });
+    expect([...document.querySelectorAll('[data-stagger-row]')].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '0ms', '0ms']);
+  });
+
+  it('#44 Replay re-reads matchMedia so a late reduce skips the cascade', async () => {
+    const pending = [];
+    const origRaf = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb) => {
+      pending.push(cb);
+      return pending.length;
+    };
+    try {
+      const media = mockMotion(false);
+      render(<MotionPatternDemo demoId="stagger" />);
+      await act(async () => {
+        pending.splice(0).forEach((cb) => cb(0));
+      });
+      await act(async () => {
+        pending.splice(0).forEach((cb) => cb(0));
+      });
+
+      await act(async () => {
+        media.setReduce(true);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Replay stagger/i }));
+
+      const movers = [...document.querySelectorAll('[data-stagger-mover]')];
+      movers.forEach((el) => {
+        expect(el.style.transform).toBe('translateX(0px)');
+        expect(el.style.transitionDuration).toBe('0ms');
+        expect(el.style.opacity).toBe('1');
+        expect(el.getAttribute('data-stagger-phase')).toBe('end');
+      });
+      expect([...document.querySelectorAll('[data-stagger-row]')].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '0ms', '0ms']);
+      // Replay must not have queued the start-then-play cascade.
+      expect(pending.length).toBe(0);
+    } finally {
+      window.requestAnimationFrame = origRaf;
+    }
+  });
+
+  it('#44 reduce-off cascade is unchanged: 80px, 900ms, 200ms steps', () => {
+    mockMotion(false);
+    expect(STAGGER_TRAVEL_PX).toBe(80);
+    expect(STAGGER_DURATION_MS).toBe(900);
+    expect(STAGGER_STEP_MS).toBe(200);
+    render(<MotionPatternDemo demoId="stagger" />);
+    const movers = document.querySelectorAll('[data-stagger-mover]');
+    expect(movers).toHaveLength(3);
+    movers.forEach((el) => {
+      expect(el.getAttribute('data-stagger-from')).toBe('translateX(80px)');
+      expect(el.getAttribute('data-stagger-to')).toBe('translateX(0px)');
+      expect(el.style.transitionDuration).toBe('900ms');
+      expect(el.style.opacity).toBe('1');
+    });
+    expect([...document.querySelectorAll('[data-stagger-row]')].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '200ms', '400ms']);
   });
 
   it('Scroll Reveal is its own scroll panel with Reset', () => {


### PR DESCRIPTION
## Summary
- Stagger Replay now re-reads `prefers-reduced-motion` via `useSyncExternalStore` so a DevTools / OS flip after mount is honored.
- Under reduce, Replay lands on the end state with `transition: none` / 0ms travel. Rows stay visible. No 80px / 900ms / 200ms cascade.
- Default (reduce off) cascade is unchanged: 80px, 900ms, 200ms delays, `commitStartThenPlay`.
- Spec Generator Reduced motion checkbox stays copy only.

Closes #44. Cites DESIGN.md Motion + Accessibility: honor `prefers-reduced-motion`. Do not add motion that cannot be turned off.

Do not reopen #34. Glanceable cascade stays a pass.

## Test plan
- [ ] `prefers-reduced-motion: reduce` then Replay on `/glossary/stagger`: end state, 0ms, no getAnimations cascade
- [ ] Reduce off: Inbox / Drafts / Sent still 80px / 900ms / 0-200-400
- [ ] Toggle reduce after load, then Replay: still snaps, does not start the cascade