### PR TITLE
fix: topic pill no longer covers ⌘K (#47)

### DIFF
--- a/src/components/layout/TopNav.jsx
+++ b/src/components/layout/TopNav.jsx
@@ -93,10 +93,10 @@ function PillDropdown({
   // Icon-only pills ignore this.
   labelFrom = 'lg',
   // DESIGN.md Layout: titles and tags wrap. Do not clip to half a word.
-  // min-content grows the pill to a whole word (Overlays, Celebration);
+  // min-w-0 stops the pill before the search chip (#47);
   // 5.5rem keeps short labels like Easing from collapsing. max-w wraps
   // multi-word titles at spaces so the left cluster cannot cover What's New / VibeScore.
-  labelMaxClass = 'min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]',
+  labelMaxClass = 'min-w-0 max-w-full',
 }) {
   const wrapRef = useRef(null);
   const labelBp = iconOnly ? null : (LABEL_FROM[labelFrom] || LABEL_FROM.xl);
@@ -118,7 +118,7 @@ function PillDropdown({
   }, [isOpen, onClose]);
 
   return (
-    <div ref={wrapRef} className={`relative ${iconOnly ? 'min-w-0' : 'min-w-[max(5.5rem,min-content)] max-w-full'}`}>
+    <div ref={wrapRef} className={`relative ${iconOnly ? 'min-w-0' : 'min-w-0 max-w-full'}`}>
       <button
         onClick={onToggle}
         aria-label={ariaLabel || label}
@@ -696,7 +696,7 @@ export default function TopNav({
       </div>
       <div className="relative flex items-center justify-between gap-2 px-3 sm:px-4 md:px-6 min-h-20">
         {/* Left: Logo + pills. min-w-0 flex-1 keeps this cluster from covering Whats New / VibeScore. Do not overflow-hidden this ancestor: category dropdowns are absolute and would clip. Titles wrap on spaces (DESIGN.md). min-h-20 grows with a wrapped label so the panes below stay visible (#43). */}
-        <div data-testid="nav-left-cluster" className="flex items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0 flex-1 overflow-visible pr-2">
+        <div data-testid="nav-left-cluster" className="flex flex-wrap items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0 flex-1 overflow-visible pr-2">
           <button
             onClick={onGetStarted}
             className="group relative flex items-center gap-2 lg:gap-3 font-bold tracking-tight text-zinc-900 dark:text-white shrink-0"
@@ -744,7 +744,7 @@ export default function TopNav({
 
           {/* Category */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
+          <div className="hidden md:block min-w-0">
             <PillDropdown
               icon={
                 <span className={`flex items-center gap-1.5 ${catColors.accent}`}>
@@ -754,7 +754,7 @@ export default function TopNav({
               }
               label={activeCat?.name || 'Overlays'}
               labelFrom="lg"
-              labelMaxClass="min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]"
+              labelMaxClass="min-w-0 max-w-full"
               isOpen={openDropdown === 'category'}
               onToggle={() => setOpenDropdown(openDropdown === 'category' ? null : 'category')}
               onClose={() => setOpenDropdown(null)}
@@ -786,7 +786,7 @@ export default function TopNav({
 
           {/* Component */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
+          <div className="hidden md:block min-w-0">
             <PillDropdown
               icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
               label={activeItemData?.name || 'Modal'}
@@ -822,7 +822,7 @@ export default function TopNav({
 
           {/* Build literacy: Cluster pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
+            <div className="hidden md:block min-w-0">
               <PillDropdown
                 icon={
                   <span className={`flex items-center gap-1.5 ${activeBuildColors.accent}`}>
@@ -832,7 +832,7 @@ export default function TopNav({
                 }
                 label={activeBuildCluster?.title || 'Web foundations'}
                 labelFrom="lg"
-                labelMaxClass="min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]"
+                labelMaxClass="min-w-0 max-w-full"
                 isOpen={openDropdown === 'build-cluster'}
                 onToggle={() => setOpenDropdown(openDropdown === 'build-cluster' ? null : 'build-cluster')}
                 onClose={() => setOpenDropdown(null)}
@@ -866,7 +866,7 @@ export default function TopNav({
 
           {/* Build literacy: Topic pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block min-w-[max(5.5rem,min-content)]">
+            <div className="hidden md:block min-w-0">
               <PillDropdown
                 icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
                 label={activeBuildTopicData?.title || 'Pick a topic'}

--- a/src/test/TopNav.test.jsx
+++ b/src/test/TopNav.test.jsx
@@ -128,7 +128,9 @@ describe('#33 header topic pill shows a real word', () => {
     expect(label.className).toMatch(/break-keep/);
     expect(label.className).not.toMatch(/break-words/);
     expect(label.className).toMatch(/whitespace-normal/);
-    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
+    expect(label.className).toMatch(/min-w-0/);
+    expect(label.className).toMatch(/max-w-full/);
+    expect(label.className).not.toMatch(/min-content/);
     expect(label.className).toMatch(/hidden lg:inline-block/);
   });
 
@@ -155,7 +157,9 @@ describe('#42 header topic pill wraps on spaces, not mid-word', () => {
     expect(label.className).not.toMatch(/break-words/);
     expect(label.className).not.toMatch(/break-all/);
     expect(label.className).not.toMatch(/\btruncate\b/);
-    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
+    expect(label.className).toMatch(/min-w-0/);
+    expect(label.className).toMatch(/max-w-full/);
+    expect(label.className).not.toMatch(/min-content/);
   };
 
   it('keeps Overlays as a whole word and still wraps Modal / Dialog at the space', () => {
@@ -226,5 +230,33 @@ describe('#43 wrapped header stays in flow above the panes', () => {
     const topicLabel = [...container.querySelectorAll('span')].find((el) => el.textContent === 'Confetti / Celebration');
     expect(topicLabel.className).toMatch(/break-keep/);
     expect(topicLabel.className).not.toMatch(/break-words/);
+  });
+});
+
+describe('#47 topic pill does not share pixels with search', () => {
+  it('keeps Easing a whole word and parks search in the shrink-wrapped right cluster', () => {
+    render(<TopNav {...defaultProps()} activeItem="easing" activeCatColors={CATEGORY_COLORS.motion} />);
+
+    const topicPill = screen.getByRole('button', { name: 'Easing' });
+    expect(topicPill).toHaveTextContent('Easing');
+    expect(topicPill.textContent).not.toMatch(/Easi(?!ng)/);
+    const topicLabel = [...topicPill.querySelectorAll('span')].find((el) => el.textContent === 'Easing');
+    expect(topicLabel.className).toMatch(/break-keep/);
+    expect(topicLabel.className).toMatch(/min-w-0/);
+    expect(topicLabel.className).not.toMatch(/min-content/);
+    expect(topicLabel.className).not.toMatch(/\btruncate\b/);
+
+    const left = screen.getByTestId('nav-left-cluster');
+    expect(left.className).toMatch(/flex-wrap/);
+    expect(left.className).toMatch(/min-w-0/);
+    expect(left.className).toMatch(/overflow-visible/);
+    expect(left.className).not.toMatch(/overflow-hidden/);
+    expect(left.contains(topicPill)).toBe(true);
+
+    const right = screen.getByTestId('nav-right-cluster');
+    expect(right.className).toMatch(/shrink-0/);
+    const search = screen.getByRole('button', { name: 'Search (⌘K)' });
+    expect(right.contains(search)).toBe(true);
+    expect(left.contains(search)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Left cluster `flex-wrap` + `min-w-0`. Pill labels drop `min-content` min-width so they cannot beat `max-w` and overflow onto the search chip.
- `break-keep` stays. Overlays, Celebration, and Easing remain whole words. No `break-words`, no `E..` truncate.
- Search stays in the shrink-0 right cluster. What's New / VibeScore stay visible. Dropdowns stay `overflow-visible`.
- Header stays in-flow `min-h-20`. Extra wrap height pushes panes down.

Closes #47. Cites DESIGN.md Layout: titles wrap, do not clip to half a word. Covering Easing with ⌘K is the same fail.

Does not reopen #33 / #42 / #43 / #44.

## Test plan
- [ ] /glossary/easing: Easing is the full word, not Easi⌘K. ⌘K is clickable. Pill is clickable.
- [ ] /glossary/modal and /glossary/confetti: Overlays and Celebration stay whole. ⌘K does not sit on the label.
- [ ] What's New / VibeScore still visible. Category dropdown still opens unclipped.