### PR TITLE
fix: wrap leftover topic pills before they cover ⌘K (#47)

### DIFF
--- a/src/components/layout/TopNav.jsx
+++ b/src/components/layout/TopNav.jsx
@@ -93,10 +93,10 @@ function PillDropdown({
   // Icon-only pills ignore this.
   labelFrom = 'lg',
   // DESIGN.md Layout: titles and tags wrap. Do not clip to half a word.
-  // min-w-0 stops the pill before the search chip (#47);
+  // min-content grows the pill to a whole word (Overlays, Celebration);
   // 5.5rem keeps short labels like Easing from collapsing. max-w wraps
-  // multi-word titles at spaces so the left cluster cannot cover What's New / VibeScore.
-  labelMaxClass = 'min-w-0 max-w-full',
+  // multi-word titles at spaces. The left cluster flex-wraps leftover pills onto the next header row so this min-content cannot paint over Search (#47).
+  labelMaxClass = 'min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]',
 }) {
   const wrapRef = useRef(null);
   const labelBp = iconOnly ? null : (LABEL_FROM[labelFrom] || LABEL_FROM.xl);
@@ -118,7 +118,7 @@ function PillDropdown({
   }, [isOpen, onClose]);
 
   return (
-    <div ref={wrapRef} className={`relative ${iconOnly ? 'min-w-0' : 'min-w-0 max-w-full'}`}>
+    <div ref={wrapRef} className={`relative ${iconOnly ? 'min-w-0' : 'min-w-[max(5.5rem,min-content)] max-w-full'}`}>
       <button
         onClick={onToggle}
         aria-label={ariaLabel || label}
@@ -695,7 +695,7 @@ export default function TopNav({
         <div className={`absolute inset-0 bg-gradient-to-r ${catColors.gradient} opacity-[0.10] dark:opacity-[0.18] transition-opacity duration-500`} />
       </div>
       <div className="relative flex items-center justify-between gap-2 px-3 sm:px-4 md:px-6 min-h-20">
-        {/* Left: Logo + pills. min-w-0 flex-1 keeps this cluster from covering Whats New / VibeScore. Do not overflow-hidden this ancestor: category dropdowns are absolute and would clip. Titles wrap on spaces (DESIGN.md). min-h-20 grows with a wrapped label so the panes below stay visible (#43). */}
+        {/* Left: Logo + pills. min-w-0 flex-1 stops this cluster before Search so the pill cannot share pixels with the chip (#47). flex-wrap sends extra pills to the next header row; extra height stays in-flow and pushes panes down (#43). overflow-visible so category dropdowns do not clip. Titles wrap on spaces, not mid-word (DESIGN.md Layout). */}
         <div data-testid="nav-left-cluster" className="flex flex-wrap items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0 flex-1 overflow-visible pr-2">
           <button
             onClick={onGetStarted}
@@ -744,7 +744,7 @@ export default function TopNav({
 
           {/* Category */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block min-w-0">
+          <div className="hidden md:block min-w-[max(5.5rem,min-content)] max-w-full">
             <PillDropdown
               icon={
                 <span className={`flex items-center gap-1.5 ${catColors.accent}`}>
@@ -754,7 +754,7 @@ export default function TopNav({
               }
               label={activeCat?.name || 'Overlays'}
               labelFrom="lg"
-              labelMaxClass="min-w-0 max-w-full"
+              labelMaxClass="min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]"
               isOpen={openDropdown === 'category'}
               onToggle={() => setOpenDropdown(openDropdown === 'category' ? null : 'category')}
               onClose={() => setOpenDropdown(null)}
@@ -786,7 +786,7 @@ export default function TopNav({
 
           {/* Component */}
           {siteSection === 'glossary' && (
-          <div className="hidden md:block min-w-0">
+          <div className="hidden md:block min-w-[max(5.5rem,min-content)] max-w-full">
             <PillDropdown
               icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
               label={activeItemData?.name || 'Modal'}
@@ -822,7 +822,7 @@ export default function TopNav({
 
           {/* Build literacy: Cluster pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block min-w-0">
+            <div className="hidden md:block min-w-[max(5.5rem,min-content)] max-w-full">
               <PillDropdown
                 icon={
                   <span className={`flex items-center gap-1.5 ${activeBuildColors.accent}`}>
@@ -832,7 +832,7 @@ export default function TopNav({
                 }
                 label={activeBuildCluster?.title || 'Web foundations'}
                 labelFrom="lg"
-                labelMaxClass="min-w-0 max-w-full"
+                labelMaxClass="min-w-[max(5.5rem,min-content)] max-w-[12rem] lg:max-w-[14rem] xl:max-w-[16rem]"
                 isOpen={openDropdown === 'build-cluster'}
                 onToggle={() => setOpenDropdown(openDropdown === 'build-cluster' ? null : 'build-cluster')}
                 onClose={() => setOpenDropdown(null)}
@@ -866,7 +866,7 @@ export default function TopNav({
 
           {/* Build literacy: Topic pill */}
           {siteSection === 'build' && (
-            <div className="hidden md:block min-w-0">
+            <div className="hidden md:block min-w-[max(5.5rem,min-content)] max-w-full">
               <PillDropdown
                 icon={<List size={22} className="text-zinc-500 dark:text-zinc-400" />}
                 label={activeBuildTopicData?.title || 'Pick a topic'}
@@ -901,7 +901,7 @@ export default function TopNav({
 
         </div>
 
-        {/* Right: Search + Menu. shrink-0 + z-20 so What's New / VibeScore stay visible (#15). */}
+        {/* Right: Search + Menu. shrink-0 + z-20 so Search, What's New, and VibeScore keep their own pixels (#15, #47). */}
         <div data-testid="nav-right-cluster" className="flex items-center gap-2 shrink-0 relative z-20">
           {/* Learning + Help icon-only pills, only at 2xl+ where there's room.
               Below that they live inside the hamburger menu instead. */}
@@ -1041,7 +1041,7 @@ export default function TopNav({
             <button
               onClick={() => { setSearchOpen(true); setTimeout(() => searchInputRef.current?.focus(), 50); }}
               data-tour="search"
-              className="group relative hidden md:flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] px-2.5 py-2 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
+              className="group relative hidden md:flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] shrink-0 px-2.5 py-2 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 transition-colors"
               aria-label="Search (⌘K)"
             >
               <Search size={20} />

--- a/src/test/TopNav.test.jsx
+++ b/src/test/TopNav.test.jsx
@@ -128,9 +128,7 @@ describe('#33 header topic pill shows a real word', () => {
     expect(label.className).toMatch(/break-keep/);
     expect(label.className).not.toMatch(/break-words/);
     expect(label.className).toMatch(/whitespace-normal/);
-    expect(label.className).toMatch(/min-w-0/);
-    expect(label.className).toMatch(/max-w-full/);
-    expect(label.className).not.toMatch(/min-content/);
+    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
     expect(label.className).toMatch(/hidden lg:inline-block/);
   });
 
@@ -157,9 +155,7 @@ describe('#42 header topic pill wraps on spaces, not mid-word', () => {
     expect(label.className).not.toMatch(/break-words/);
     expect(label.className).not.toMatch(/break-all/);
     expect(label.className).not.toMatch(/\btruncate\b/);
-    expect(label.className).toMatch(/min-w-0/);
-    expect(label.className).toMatch(/max-w-full/);
-    expect(label.className).not.toMatch(/min-content/);
+    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
   };
 
   it('keeps Overlays as a whole word and still wraps Modal / Dialog at the space', () => {
@@ -234,21 +230,23 @@ describe('#43 wrapped header stays in flow above the panes', () => {
 });
 
 describe('#47 topic pill does not share pixels with search', () => {
-  it('keeps Easing a whole word and parks search in the shrink-wrapped right cluster', () => {
-    render(<TopNav {...defaultProps()} activeItem="easing" activeCatColors={CATEGORY_COLORS.motion} />);
+  const assertWholeWord = (label, text) => {
+    expect(label).toBeTruthy();
+    expect(label.textContent).toBe(text);
+    expect(label.className).toMatch(/whitespace-normal/);
+    expect(label.className).toMatch(/break-keep/);
+    expect(label.className).not.toMatch(/break-words/);
+    expect(label.className).not.toMatch(/break-all/);
+    expect(label.className).not.toMatch(/\btruncate\b/);
+    expect(label.className).toMatch(/min-w-\[max\(5.5rem,min-content\)\]/);
+  };
 
-    const topicPill = screen.getByRole('button', { name: 'Easing' });
-    expect(topicPill).toHaveTextContent('Easing');
-    expect(topicPill.textContent).not.toMatch(/Easi(?!ng)/);
-    const topicLabel = [...topicPill.querySelectorAll('span')].find((el) => el.textContent === 'Easing');
-    expect(topicLabel.className).toMatch(/break-keep/);
-    expect(topicLabel.className).toMatch(/min-w-0/);
-    expect(topicLabel.className).not.toMatch(/min-content/);
-    expect(topicLabel.className).not.toMatch(/\btruncate\b/);
-
+  const assertClustersApart = (topicName) => {
+    const topicPill = screen.getByRole('button', { name: topicName });
     const left = screen.getByTestId('nav-left-cluster');
     expect(left.className).toMatch(/flex-wrap/);
     expect(left.className).toMatch(/min-w-0/);
+    expect(left.className).toMatch(/flex-1/);
     expect(left.className).toMatch(/overflow-visible/);
     expect(left.className).not.toMatch(/overflow-hidden/);
     expect(left.contains(topicPill)).toBe(true);
@@ -256,7 +254,38 @@ describe('#47 topic pill does not share pixels with search', () => {
     const right = screen.getByTestId('nav-right-cluster');
     expect(right.className).toMatch(/shrink-0/);
     const search = screen.getByRole('button', { name: 'Search (⌘K)' });
+    expect(search.className).toMatch(/shrink-0/);
     expect(right.contains(search)).toBe(true);
     expect(left.contains(search)).toBe(false);
+    expect(screen.getByRole('button', { name: /What'?s new/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /VibeScore/i })).toBeInTheDocument();
+  };
+
+  it('keeps Easing a whole word and wraps leftover pills instead of painting over ⌘K', () => {
+    render(<TopNav {...defaultProps()} activeItem="easing" activeCatColors={CATEGORY_COLORS.motion} />);
+
+    const topicPill = screen.getByRole('button', { name: 'Easing' });
+    expect(topicPill).toHaveTextContent('Easing');
+    expect(topicPill.textContent).not.toMatch(/E\.\./);
+    expect(topicPill.textContent).not.toMatch(/Easi(?!ng)/);
+    const topicLabel = [...topicPill.querySelectorAll('span')].find((el) => el.textContent === 'Easing');
+    assertWholeWord(topicLabel, 'Easing');
+    assertClustersApart('Easing');
+  });
+
+  it('keeps Modal / Dialog and Confetti / Celebration whole and off the search chip', () => {
+    const { rerender } = render(<TopNav {...defaultProps()} activeItem="modal" />);
+    const modalPill = screen.getByRole('button', { name: 'Modal / Dialog' });
+    const modalLabel = [...modalPill.querySelectorAll('span')].find((el) => el.textContent === 'Modal / Dialog');
+    assertWholeWord(modalLabel, 'Modal / Dialog');
+    assertClustersApart('Modal / Dialog');
+
+    rerender(<TopNav {...defaultProps()} activeItem="confetti" activeCatColors={CATEGORY_COLORS.motion} />);
+    const confettiPill = screen.getByRole('button', { name: 'Confetti / Celebration' });
+    expect(confettiPill.textContent).toMatch(/Celebration/);
+    expect(confettiPill.textContent).not.toMatch(/Celebrat(?!ion)/);
+    const confettiLabel = [...confettiPill.querySelectorAll('span')].find((el) => el.textContent === 'Confetti / Celebration');
+    assertWholeWord(confettiLabel, 'Confetti / Celebration');
+    assertClustersApart('Confetti / Celebration');
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #49. Leftover pills keep a whole-word min-width (`min-w-[max(5.5rem,min-content)]`) and `flex-wrap` onto the next header row instead of shrinking under Search.
- Left cluster is `min-w-0 flex-1 overflow-visible`, so it stops before ⌘K and dropdowns do not clip. Search stays `shrink-0` in the right cluster. What's New / VibeScore stay visible.
- `break-keep` stays. Overlays, Celebration, and Easing remain whole words. No `break-words`, no `E..` truncate. Header stays in-flow `min-h-20`; extra wrap height pushes panes down.

Cites #47 and DESIGN.md Layout: titles and tags wrap. Do not clip to half a word. Covering Easing with ⌘K is the same fail as clipping a word.

Does not reopen #33 / #42 / #43.

## Test plan
- [ ] `/glossary/easing`: Easing is the full word, not Easi⌘K. Pill and ⌘K are both clickable. `elementFromPoint` on the pill's right edge does not hit ⌘K.
- [ ] `/glossary/modal` and `/glossary/confetti`: Overlays and Celebration stay whole. ⌘K does not sit on the label.
- [ ] What's New / VibeScore still visible. Category dropdown still opens unclipped. Wrapped header still pushes Try It down.