### PR TITLE
fix: stagger reduce-on copy says travel is off (#48)

### DIFF
--- a/src/components/demos/MotionPatternDemo.jsx
+++ b/src/components/demos/MotionPatternDemo.jsx
@@ -284,9 +284,11 @@ function StaggerPreview({ reduced: reducedProp }) {
         data-stagger-teach=""
         className="whitespace-normal break-words text-sm leading-relaxed text-zinc-600 dark:text-zinc-300"
       >
-        {mode === 'together'
-          ? `All at once: Inbox, Drafts, and Sent slide ${STAGGER_TRAVEL_PX}px together. No waiting.`
-          : `200ms stagger: Inbox slides ${STAGGER_TRAVEL_PX}px first. Drafts waits 200ms. Sent waits 400ms. Watch Inbox, then Drafts, then Sent.`}
+        {reduced
+          ? 'Reduced motion: Inbox, Drafts, and Sent are already in place. Travel is off.'
+          : mode === 'together'
+            ? `All at once: Inbox, Drafts, and Sent slide ${STAGGER_TRAVEL_PX}px together. No waiting.`
+            : `200ms stagger: Inbox slides ${STAGGER_TRAVEL_PX}px first. Drafts waits 200ms. Sent waits 400ms. Watch Inbox, then Drafts, then Sent.`}
       </p>
       <ul
         ref={wellRef}

--- a/src/test/MotionPatternDemo.test.jsx
+++ b/src/test/MotionPatternDemo.test.jsx
@@ -270,6 +270,18 @@ describe('#25 motion pattern previews are real', () => {
     }
   });
 
+  it('#48 reduce-on teaching line says travel is off, not 200ms', () => {
+    mockMotion(true);
+    render(<MotionPatternDemo demoId="stagger" />);
+    const teach = document.querySelector('[data-stagger-teach]');
+    expect(teach).toBeTruthy();
+    expect(teach.textContent).toMatch(/Travel is off/i);
+    expect(teach.textContent).not.toMatch(/waits 200ms/);
+    expect(teach.textContent).not.toMatch(/waits 400ms/);
+    expect(teach.textContent).not.toMatch(/slides 80px first/);
+    expect([...document.querySelectorAll('[data-stagger-row]')].map((r) => r.getAttribute('data-stagger-delay'))).toEqual(['0ms', '0ms', '0ms']);
+  });
+
   it('#44 reduce-off cascade is unchanged: 80px, 900ms, 200ms steps', () => {
     mockMotion(false);
     expect(STAGGER_TRAVEL_PX).toBe(80);


### PR DESCRIPTION
## Summary
- Under `prefers-reduced-motion: reduce`, the Try It line now says travel is off so it matches the 0 / 0 / 0 chips.
- Reduce-off copy is unchanged (200ms stagger / 80px / 400ms).
- Does not reopen #44. Motion path is untouched.

Closes #48. Cites DESIGN.md glanceable demos and CLAUDE.md: previews teach at a glance.

#47 (pill vs ⌘K) is a separate live pass.

## Test plan
- [ ] Reduce on, 200ms stagger selected, Replay: chips 0/0/0, caption says travel is off, no 200/400 teaching
- [ ] Reduce off: Inbox slides 80px first, Drafts waits 200ms, Sent waits 400ms