### PR TITLE
fix: fail the build if Firebase env is missing (#52)

### DIFF
--- a/scripts/assertFirebaseEnv.js
+++ b/scripts/assertFirebaseEnv.js
@@ -1,0 +1,9 @@
+/** Fail a production build when Firebase env is missing. Empty VITE_* inlines as void 0 and kills #root (#52). */
+export function assertFirebaseEnv(env, { command = 'build' } = {}) {
+  if (command !== 'build') return;
+  const projectId = env?.VITE_FIREBASE_PROJECT_ID;
+  if (projectId && String(projectId).trim()) return;
+  throw new Error(
+    'VITE_FIREBASE_PROJECT_ID is required to build. Empty Firebase config ships a dead #root.',
+  );
+}

--- a/src/test/assertFirebaseEnv.test.js
+++ b/src/test/assertFirebaseEnv.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { assertFirebaseEnv } from '../../scripts/assertFirebaseEnv.js';
+
+describe('#52 fail the build if Firebase projectId is missing', () => {
+  it('throws when projectId is missing on build', () => {
+    expect(() => assertFirebaseEnv({}, { command: 'build' })).toThrow(/VITE_FIREBASE_PROJECT_ID/);
+    expect(() => assertFirebaseEnv({ VITE_FIREBASE_PROJECT_ID: '' }, { command: 'build' })).toThrow(/dead #root/);
+    expect(() => assertFirebaseEnv({ VITE_FIREBASE_PROJECT_ID: '   ' }, { command: 'build' })).toThrow(/required to build/);
+  });
+
+  it('passes when projectId is present on build', () => {
+    expect(() =>
+      assertFirebaseEnv({ VITE_FIREBASE_PROJECT_ID: 'vibe-glossary' }, { command: 'build' }),
+    ).not.toThrow();
+  });
+
+  it('does not fail vite serve or tests', () => {
+    expect(() => assertFirebaseEnv({}, { command: 'serve' })).not.toThrow();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,19 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import { assertFirebaseEnv } from './scripts/assertFirebaseEnv.js';
+
+function requireFirebaseEnv() {
+  return {
+    name: 'require-firebase-env',
+    config(_cfg, { command, mode }) {
+      const env = loadEnv(mode, process.cwd(), 'VITE_');
+      assertFirebaseEnv(env, { command });
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [requireFirebaseEnv(), react()],
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- Production \`vite build\` now throws if \`VITE_FIREBASE_PROJECT_ID\` is missing or blank.
- That is what shipped \`index-CpnuYif5.js\` with \`apiKey: void 0\` and an empty \`#root\`.
- \`vite\` serve and tests are unchanged. \`src/firebase.js\` is untouched.

Closes #52.

#48/#47/#44 stay closed. Live \`index-DLUakZTP.js\` does not need a redeploy for this guard.

## Test plan
- [ ] \`vite build\` without \`.env\` fails with the dead #root message
- [ ] \`vite build\` with the Mac checkout \`.env\` still succeeds
- [ ] vitest \`assertFirebaseEnv\` 3 tests pass
- [ ] Live site stays \`index-DLUakZTP.js\` until a later product ship